### PR TITLE
Enable CI for multiple python version - Refactor tests to separate integration and unit tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -8,3 +8,5 @@ flake8-ignore =
     basin3d/*.py ALL
     tests/*
     docs/*
+markers =
+    integration: integration test

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,47 @@ from basin3d.core.models import DataSource, MeasurementTimeseriesTVPObservation
 from basin3d.plugins.usgs import USGSMeasurementTimeseriesTVPObservationAccess
 
 
+def pytest_addoption(parser):
+    """
+    Add execution options to the commandline
+    :param parser:
+    :return:
+    """
+
+    parser.addoption(
+        "--runintegration", action="store_true", default=False, help=f"run integration tests"
+    )
+
+
+def pytest_configure(config):
+    """
+    Add pytext init lines
+    :param config:
+    :return:
+    """
+    config.addinivalue_line("markers", "integration: Mark test as integration.")
+
+
+def pytest_collection_modifyitems(config, items):
+    """
+    Modify the tests to skip integration unless specified
+    :param config:
+    :param items:
+    :return:
+    """
+
+    # Determine if any markers need to be skipped.
+    if config.getoption("--runintegration"):
+        # --runintegration given in cli: do not skip integration tests
+        return
+
+    markers_skip_integration = pytest.mark.skip(reason="need --runintegration option to run")
+
+    for item in items:
+        if "integration" in item.keywords:
+            item.add_marker(markers_skip_integration)
+
+
 @pytest.fixture
 def datasource(name='Alpha', location='https://asource.foo/', id_prefix='A'):
     """

--- a/tests/test_plugins_usgs.py
+++ b/tests/test_plugins_usgs.py
@@ -10,6 +10,7 @@ from basin3d.core.types import FeatureTypes, TimeFrequency, ResultQuality, Sampl
 from basin3d.synthesis import register, SynthesisException, get_timeseries_data
 
 
+@pytest.mark.integration
 def test_measurement_timeseries_tvp_observations_usgs():
     """ Test USGS Timeseries data query"""
 
@@ -56,10 +57,12 @@ def test_measurement_timeseries_tvp_observations_usgs():
         synthesizer.measurement_timeseries_tvp_observations(**query2)
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize("query, feature_type", [({"id": "USGS-13"}, "region"),
                                                  ({"id": "USGS-0102"}, "subregion"),
                                                  ({"id": "USGS-011000"}, "basin"),
                                                  ({"id": "USGS-01020004"}, "subbasin")], ids=["region", "subregion",
+
                                                                                               "basin", "subbasin"])
 def test_usgs_monitoring_feature(query, feature_type):
     """Test USGS search by region  """
@@ -72,6 +75,7 @@ def test_usgs_monitoring_feature(query, feature_type):
     assert FeatureTypes.TYPES[monitoring_feature.feature_type] == feature_type.upper()
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize("query, expected_count", [({}, 2889),
                                                    ({"feature_type": "region"}, 21),
                                                    ({"feature_type": "subregion"}, 222),
@@ -86,7 +90,8 @@ def test_usgs_monitoring_feature(query, feature_type):
                                                    ({"feature_type": "point"}, 0),
                                                    ({"parent_features": ['USGS-02']}, 118),
                                                    (
-                                                   {"parent_features": ['USGS-02020004'], "feature_type": "point"}, 48),
+                                                           {"parent_features": ['USGS-02020004'],
+                                                            "feature_type": "point"}, 48),
                                                    ({"parent_features": ['USGS-0202'], "feature_type": "subbasin"}, 8),
                                                    ({"parent_features": ['USGS-020200'], "feature_type": "point"}, 0)],
                          ids=["all", "region", "subregion",
@@ -116,6 +121,7 @@ def test_usgs_monitoring_features(query, expected_count):
     assert count == expected_count
 
 
+@pytest.mark.integration
 def test_usgs_get_data():
     synthesizer = register(['basin3d.plugins.usgs.USGSDataSourcePlugin'])
     usgs_df, usgs_metadata = get_timeseries_data(


### PR DESCRIPTION
adds integration markers and tags for tests

Closes #46

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Unit tests
- [X] Integration tests 
- [ ] Test coverage >= 90% <- has 79% coverage
- [X] Flake8 Tests 
- [X] Mypy Tests 
- [X] Other <-ran `pytest --runintegration` and integration tests were runned

### Test Configuration
* Python Version: 3.7

## PR Self Evaluation
strikethrough things that don’t make sense for your PR

- [X] My code follows the agreed upon best practices
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- ~[ ] I have made corresponding changes to the documentation~
- [X] My changes generate no new warnings
- [X] I have added tests or modified existing tests that prove my fix is effective or that my feature works
- [X] Existing unit tests pass locally with my changes
- ~[ ] Any dependent changes have been merged and published in the appropriate modules~
- [X] I have performed a self-review of my own code

