### PR TITLE
Github Actions failing for mypy on specific types libraries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest pytest-flake8 pytest-mypy pytest-cov $(cat docs/requirements.txt)
+        pip install flake8 pytest pytest-flake8 pytest-mypy pytest-cov types-PyYAML types-chardet types-cryptography types-requests $(cat docs/requirements.txt)
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         # Output dependency versions
         pip freeze
@@ -32,12 +32,16 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Static type checking with mypy
+      run: |
+        mypy -p basin3d  --python-version ${{ matrix.python-version }} > mypy.out
+        cat mypy.out
     - name: Make artifact directory
       run: |
         mkdir -p ${{ github.workspace }}/artifacts
     - name: Test with pytest
       run: |
-        PYTHONPATH=. pytest -v -m "not flake8" --cov=basin3d --cov-report html:${{ github.workspace }}/artifacts
+        PYTHONPATH=. pytest -v -m "not flake8 and not mypy" --cov=basin3d --cov-report term --cov-report html:${{ github.workspace }}/artifacts
     - name: Documentation and Doctests
       run: |
         cd docs


### PR DESCRIPTION
Changes that make it easier to discern mypy errors
+ Adds new job step for mypy
+ Installs mypy libraries needed for testing
+ changes "Test with pytest" job step to exclude mpypy

Closes #86

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Please include the syntax that is relevant (Fixes, Closes, Implements, Issue ). Only use Issue if this pull request doesn't resolve the entire issue

Fixes #(issue) 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Unit tests
- [X] Integration tests - ran `pytest -m integration --runintegration`
- [X] Test coverage >= 90% - Test coverage is 91%
- [X] Flake8 Tests 
- [X] Mypy Tests 
- [ ] Other - confirmed fix works for github actions

### Test Configuration
* Python Version: 3.8

## PR Self Evaluation
strikethrough things that don’t make sense for your PR

- [X] My code follows the agreed upon best practices
- ~I have commented my code, particularly in hard-to-understand areas~
- ~I have made corresponding changes to the documentation~
- [X] My changes generate no new warnings
- ~I have added tests or modified existing tests that prove my fix is effective or that my feature works~
- [X] Existing unit tests pass locally with my changes
- ~Any dependent changes have been merged and published in the appropriate modules~
- [X] I have performed a self-review of my own code

