### PR TITLE
Add missing h5py module to docs/requirements.py

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+h5py
 sphinx
 sphinx-autodoc-typehints
 graphviz


### PR DESCRIPTION
Closes #101

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Unit tests
- [ ] Integration tests 
- [ ] Test coverage >= 90%
- [x] Flake8 Tests 
- [x] Mypy Tests 
- [ ] Other - generated ReadTheDocs: https://basin3d.readthedocs.io/en/issue-101/quick_guide.html

### Test Configuration
* Python Version: 3.7.11

## PR Self Evaluation
- [x] My code follows the agreed upon best practices
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
- [x] My changes generate no new warnings
~- [ ] I have added tests or modified existing tests that prove my fix is effective or that my feature works~
- [x] Existing unit tests pass locally with my changes
~- [ ] Any dependent changes have been merged and published in the appropriate modules~
- [x] I have performed a self-review of my own code

