### PR TITLE
Issue 94: Enable full statistic functionality

### DIFF
--- a/basin3d/core/models.py
+++ b/basin3d/core/models.py
@@ -1317,6 +1317,9 @@ class MeasurementMetadataMixin(object):
     Metadata attributes for Observations type Measurement
     """
 
+    #: Statistical Instantaneous
+    STATISTIC_INSTANTANEOUS = "INSTANT"
+
     #: Statistical Mean
     STATISTIC_MEAN = "MEAN"
 

--- a/basin3d/core/types.py
+++ b/basin3d/core/types.py
@@ -14,7 +14,6 @@
     :backlinks: top
 
 """
-import datetime as dt
 
 
 class SpatialSamplingShapes(object):

--- a/tests/test_plugins_usgs.py
+++ b/tests/test_plugins_usgs.py
@@ -90,9 +90,7 @@ def test_usgs_monitoring_feature(query, feature_type):
                                                    ({"feature_type": "horizontal path"}, 0),
                                                    ({"feature_type": "point"}, 0),
                                                    ({"parent_features": ['USGS-02']}, 118),
-                                                   (
-                                                           {"parent_features": ['USGS-02020004'],
-                                                            "feature_type": "point"}, 48),
+                                                   ({"parent_features": ['USGS-02020004'], "feature_type": "point"}, 49),
                                                    ({"parent_features": ['USGS-0202'], "feature_type": "subbasin"}, 8),
                                                    ({"parent_features": ['USGS-020200'], "feature_type": "point"}, 0)],
                          ids=["all", "region", "subregion",
@@ -134,17 +132,19 @@ def test_usgs_get_data():
     # check the dataframe
     assert isinstance(usgs_df, pd.DataFrame) is True
     for column_name in list(usgs_df.columns):
-        assert column_name in ['TIMESTAMP', 'USGS-09110000__RDC', 'USGS-09110000__WT']
-    assert usgs_df.shape == (4, 3)
-    alpha_data = usgs_df.get('USGS-09110000__RDC')
+        assert column_name in ['TIMESTAMP', 'USGS-09110000__RDC__MEAN', 'USGS-09110000__WT__MEAN', 'USGS-09110000__WT__MIN', 'USGS-09110000__WT__MAX']
+    assert usgs_df.shape == (4, 5)
+    alpha_data = usgs_df.get('USGS-09110000__RDC__MEAN')
     assert list(alpha_data.values) == [4.2475270499999995, 4.219210203, 4.134259662, 4.332477591]
     assert list(alpha_data.index) == [dt.datetime(2019, 10, num) for num in range(25, 29)]
+
     # make sure the temporary data directory is removed
     temp_dir = os.path.join(os.getcwd(), 'temp_data')
     assert os.path.isdir(temp_dir) is False
+
     # check the metadata store
     # Get synthesized variable field names and values
-    var_metadata = usgs_metadata_df['USGS-09110000__RDC']
+    var_metadata = usgs_metadata_df['USGS-09110000__RDC__MEAN']
     assert var_metadata['data_start'] == dt.datetime(2019, 10, 25)
     assert var_metadata['data_end'] == dt.datetime(2019, 10, 28)
     assert var_metadata['records'] == 4
@@ -158,3 +158,30 @@ def test_usgs_get_data():
     assert var_metadata['sampling_feature_id'] == 'USGS-09110000'
     assert var_metadata['datasource'] == 'USGS'
     assert var_metadata['datasource_variable'] == '00060'
+
+    assert usgs_metadata_df['USGS-09110000__WT__MIN']['statistic'] == 'MIN'
+    assert usgs_metadata_df['USGS-09110000__WT__MAX']['statistic'] == 'MAX'
+
+    # check filtering by single statistic
+    usgs_data = get_timeseries_data(synthesizer=synthesizer, monitoring_features=["USGS-09110000"],
+                                    observed_property_variables=['RDC', 'WT'], start_date='2019-10-25',
+                                    end_date='2019-10-28', statistic=['MEAN'])
+    usgs_df = usgs_data.data
+
+    # check the dataframe
+    assert isinstance(usgs_df, pd.DataFrame) is True
+    for column_name in list(usgs_df.columns):
+        assert column_name in ['TIMESTAMP', 'USGS-09110000__RDC__MEAN', 'USGS-09110000__WT__MEAN']
+    assert usgs_df.shape == (4, 3)
+
+    # check filtering by multiple statistic
+    usgs_data = get_timeseries_data(synthesizer=synthesizer, monitoring_features=["USGS-09110000"],
+                                    observed_property_variables=['RDC', 'WT'], start_date='2019-10-25',
+                                    end_date='2019-10-28', statistic=['MIN', 'MAX'])
+    usgs_df = usgs_data.data
+
+    # check the dataframe
+    assert isinstance(usgs_df, pd.DataFrame) is True
+    for column_name in list(usgs_df.columns):
+        assert column_name in ['TIMESTAMP', 'USGS-09110000__WT__MIN', 'USGS-09110000__WT__MAX']
+    assert usgs_df.shape == (4, 3)

--- a/tests/testplugins/alpha.py
+++ b/tests/testplugins/alpha.py
@@ -5,6 +5,7 @@ from basin3d.core.models import AbsoluteCoordinate, AltitudeCoordinate, Coordina
     GeographicCoordinate, MeasurementTimeseriesTVPObservation, MonitoringFeature, RelatedSamplingFeature, \
     RepresentativeCoordinate, SpatialSamplingShapes, VerticalCoordinate
 from basin3d.core.plugin import DataSourcePluginPoint, basin3d_plugin, basin3d_plugin_access
+from basin3d.core.synthesis import QUERY_PARAM_STATISTICS, QUERY_PARAM_MONITORING_FEATURES
 
 logger = logging.getLogger(__name__)
 
@@ -54,15 +55,23 @@ def find_measurement_timeseries_tvp_observations(self, **kwargs):
     from datetime import datetime
     for num in range(1, 10):
         data.append((datetime(2016, 2, num), num * 0.3454))
-    data = [data, data, []]
-    observed_property_variables = ["Acetate", "Acetate", "Aluminum"]
-    units = ['nm', 'nm', 'mg/L']
+    data = [data, data, [], data]
+    observed_property_variables = ["Acetate", "Acetate", "Aluminum", "Aluminum"]
+    units = ['nm', 'nm', 'mg/L', 'mg/L']
+    statistics = ['MEAN', 'MAX', 'MEAN', 'MAX']
 
-    for num in range(1, 4):
+    for num in range(1, 5):
+        if kwargs:
+            if QUERY_PARAM_MONITORING_FEATURES in kwargs and kwargs[QUERY_PARAM_MONITORING_FEATURES]:
+                if str(num) not in kwargs[QUERY_PARAM_MONITORING_FEATURES]:
+                    continue
+            if QUERY_PARAM_STATISTICS in kwargs and kwargs[QUERY_PARAM_STATISTICS]:
+                if statistics[num - 1] not in kwargs[QUERY_PARAM_STATISTICS]:
+                    continue
         yield MeasurementTimeseriesTVPObservation(
             plugin_access=self,
             id=num,
-            observed_property_variable=observed_property_variables[num-1],
+            observed_property_variable=observed_property_variables[num - 1],
             utc_offset=-8 - num,
             feature_of_interest=MonitoringFeature(
                 plugin_access=self,
@@ -95,12 +104,12 @@ def find_measurement_timeseries_tvp_observations(self, **kwargs):
                                            role=RelatedSamplingFeature.ROLE_PARENT)]
             ),
             feature_of_interest_type=FeatureTypes.POINT,
-            unit_of_measurement=units[num-1],
+            unit_of_measurement=units[num - 1],
             aggregation_duration=TimeFrequency.DAY,
             result_quality="CHECKED",
             time_reference_position=None,
-            statistic="MEAN",
-            result_points=data[num-1]
+            statistic=statistics[num - 1],
+            result_points=data[num - 1]
         )
 
 


### PR DESCRIPTION
Closes #94

- Adds querying functionality for statistic, i.e., single or multiple statistics can be requested from data sources
- Enable specified statistics to be returned from USGS Daily Values, i.e., removed hardcoded MEAN from USGS plugin
- Adds/updates unit and integration tests
- Fixes flake8 issues in all modules modified for this functionality

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update -- DONE.

## How Has This Been Tested?
- [x] Unit tests
- [x] Integration tests 
~- [ ] Test coverage >= 90%~
- [x] Flake8 Tests: a few known issues remain
- [x] Mypy Tests 
~- [ ] Other - <describe manual tests for the reviewer>~

### Test Configuration
* Python Version: 3.7.11

## PR Self Evaluation
- [x] My code follows the agreed upon best practices
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests or modified existing tests that prove my fix is effective or that my feature works
- [x] Existing unit tests pass locally with my changes
~- [ ] Any dependent changes have been merged and published in the appropriate modules~
- [x] I have performed a self-review of my own code

