### PR TITLE
Query information should be added to the return

### DIFF
--- a/basin3d/core/plugin.py
+++ b/basin3d/core/plugin.py
@@ -21,7 +21,7 @@ from typing import Dict
 
 from basin3d.core.catalog import CatalogTinyDb
 from basin3d.core.models import DataSource
-from basin3d.core.types import FeatureTypes
+from basin3d.core.schema.enum import FeatureTypeEnum
 
 logger = logging.getLogger(__name__)
 
@@ -30,12 +30,12 @@ def get_feature_type(feature_type, return_format="enum"):
     """
     Return the feature type if exists in the request
     :param feature_type:
-    :param return_format: "enum" (default) = the FeatureTypes enum,
+    :param return_format: "enum" (default) = the FeatureTypeEnum enum,
                    otherwise return the text version
     :return: the feature_type in the format specified, None if none exists
     """
     if feature_type:
-        for k, v in FeatureTypes.TYPES.items():
+        for k, v in FeatureTypeEnum.__members__.items():
             ft = v.lower()
             if ft == feature_type.lower():
                 if return_format == "enum":

--- a/basin3d/core/schema/enum.py
+++ b/basin3d/core/schema/enum.py
@@ -1,0 +1,105 @@
+"""
+`basin3d.core.schema.enum`
+***************************
+
+.. currentmodule:: basin3d.core.schema
+
+:platform: Unix, Mac
+:synopsis: BASIN-3D Enumeration Schema
+:module author: Val Hendrix <vhendrix@lbl.gov>
+:module author: Danielle Svehla Christianson <dschristianson@lbl.gov>
+
+.. contents:: Contents
+    :local:
+    :backlinks: top
+
+
+"""
+from enum import Enum
+
+from basin3d.core.types import SpatialSamplingShapes
+
+# From https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#timeseries-offset-aliases
+PANDAS_TIME_FREQUENCY_MAP = {
+    'YEAR': 'A',
+    'MONTH': 'M',
+    'DAY': 'D',
+    'HOUR': 'H',
+    'MINUTE': 'T',
+    'SECOND': 'S'
+}
+
+
+class BaseEnum(Enum):
+    """Base Enumeration Class that adds some helper methods"""
+
+    @classmethod
+    def values(cls):
+        role_names = [member.value for role, member in cls.__members__.items()]
+        return role_names
+
+    @classmethod
+    def names(cls):
+        return cls._member_names_
+
+
+class TimeFrequencyEnum(str, BaseEnum):
+    """
+    Enumeration for time frequencies
+    """
+    # ToDo: Check OGC for correct term (i.e., replace TimeFrequency)
+
+    YEAR = "YEAR"
+    MONTH = "MONTH"
+    DAY = "DAY"
+    HOUR = "HOUR"
+    MINUTE = "MINUTE"
+    SECOND = "SECOND"
+
+
+class FeatureTypeEnum(str, BaseEnum):
+    """Enumeration for Feature Types"""
+    REGION = "REGION"
+    SUBREGION = "SUBREGION"
+    BASIN = "BASIN"
+    SUBBASIN = "SUBBASIN"
+    WATERSHED = "WATERSHED"
+    SUBWATERSHED = "SUBWATERSHED"
+    SITE = "SITE"
+    PLOT = "PLOT"
+    HORIZONTAL_PATH = "HORIZONTAL PATH"
+    VERTICAL_PATH = "VERTICAL PATH"
+    POINT = "POINT"
+
+
+FEATURE_SHAPE_TYPES = {
+    SpatialSamplingShapes.SHAPE_POINT: [FeatureTypeEnum.POINT],
+    SpatialSamplingShapes.SHAPE_CURVE: [FeatureTypeEnum.HORIZONTAL_PATH, FeatureTypeEnum.VERTICAL_PATH],
+    SpatialSamplingShapes.SHAPE_SURFACE: [FeatureTypeEnum.REGION, FeatureTypeEnum.SUBREGION, FeatureTypeEnum.BASIN,
+                                          FeatureTypeEnum.SUBBASIN,
+                                          FeatureTypeEnum.WATERSHED,
+                                          FeatureTypeEnum.SUBWATERSHED, FeatureTypeEnum.SITE, FeatureTypeEnum.PLOT],
+    SpatialSamplingShapes.SHAPE_SOLID: []
+}
+
+
+class ResultQualityEnum(str, BaseEnum):
+    """Enumeration for Result Quality"""
+
+    #: The result has been checked for quality
+    CHECKED = "CHECKED"
+
+    #: The result is raw or unchecked for quality
+    UNCHECKED = "UNCHECKED"
+
+    #: The result contains checked and unchecked portions
+    PARTIALLY_CHECKED = "PARTIALLY_CHECKED"
+
+
+class StatisticEnum(str, BaseEnum):
+    """Enumeration for Statistics"""
+    INSTANT = "INSTANT"
+    MEAN = "MEAN"
+    MIN = "MIN"
+    MAX = "MAX"
+    TOTAL = "TOTAL"

--- a/basin3d/core/types.py
+++ b/basin3d/core/types.py
@@ -36,66 +36,6 @@ class SpatialSamplingShapes(object):
     SHAPE_POINT = "POINT"
 
 
-class FeatureTypes(object):
-    """
-    Feature Types where an Observation can be made.
-
-    Controlled CV list that is maintained. USGS Watershed Boundry Dataset is used.
-    The goal is to strike a balance between commonly used hierarchical levels and features
-    versus a runaway list of FeatureTypes. OGC O&M suggests that Features should be
-    determined as needed.
-    """
-
-    REGION = 0
-    SUBREGION = 1
-    BASIN = 2
-    SUBBASIN = 3
-    WATERSHED = 4
-    SUBWATERSHED = 5
-    SITE = 6
-    PLOT = 7
-    HORIZONTAL_PATH = 8  # Rivers, Transects
-    VERTICAL_PATH = 9  # Towers, Boreholes, Trees, Pits
-    POINT = 10
-
-    TYPES = {
-        REGION: "REGION",
-        SUBREGION: "SUBREGION",
-        BASIN: "BASIN",
-        SUBBASIN: "SUBBASIN",
-        WATERSHED: "WATERSHED",
-        SUBWATERSHED: "SUBWATERSHED",
-        SITE: "SITE",
-        PLOT: "PLOT",
-        HORIZONTAL_PATH: "HORIZONTAL PATH",
-        VERTICAL_PATH: "VERTICAL PATH",
-        POINT: "POINT"
-    }
-
-    SHAPE_TYPES = {
-        SpatialSamplingShapes.SHAPE_POINT: [POINT],
-        SpatialSamplingShapes.SHAPE_CURVE: [HORIZONTAL_PATH, VERTICAL_PATH],
-        SpatialSamplingShapes.SHAPE_SURFACE: [REGION, SUBREGION, BASIN, SUBBASIN, WATERSHED,
-                                              SUBWATERSHED, SITE, PLOT],
-        SpatialSamplingShapes.SHAPE_SOLID: []
-    }
-
-
-class ResultQuality(object):
-    """
-    Controlled Vocabulary for result quality assessment
-    """
-
-    #: The result has been checked for quality
-    RESULT_QUALITY_CHECKED = "CHECKED"
-
-    #: The result is raw or unchecked for quality
-    RESULT_QUALITY_UNCHECKED = "UNCHECKED"
-
-    #: The result contains checked and unchecked portions
-    RESULT_QUALITY_PARTIALLY_CHECKED = "PARTIALLY_CHECKED"
-
-
 class SamplingMedium:
     """
     Types of sampling mediums for Observed Properties
@@ -109,25 +49,3 @@ class SamplingMedium:
     SAMPLING_MEDIUMS = [WATER, GAS, SOLID_PHASE, OTHER, NOT_APPLICABLE]
 
 
-class TimeFrequency:
-    """
-    Types of time frequencies
-    """
-    # ToDo: Check OGC for correct term (i.e., replace TimeFrequency)
-
-    YEAR = "YEAR"
-    MONTH = "MONTH"
-    DAY = "DAY"
-    HOUR = "HOUR"
-    MINUTE = "MINUTE"
-    SECOND = "SECOND"
-
-    # From https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#timeseries-offset-aliases
-    PANDAS_FREQUENCY_MAP = {
-        YEAR: 'A',
-        MONTH: 'M',
-        DAY: 'D',
-        HOUR: 'H',
-        MINUTE: 'T',
-        SECOND: 'S'
-    }

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,10 +1,10 @@
 # Global options:
 
 [mypy]
-python_version = 3.7
+python_version = 3.8
 warn_return_any = True
 
 #flag may be useful to debug misspelled section names.
 warn_unused_configs = True
-
 ignore_missing_imports = True
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pyyaml<6.0
 tables
 requests
 tinydb
+pydantic

--- a/setup.py
+++ b/setup.py
@@ -54,10 +54,5 @@ setup(name='basin3d',
       data_files=['basin3d/data/basin3d_variables_hydrology.csv',
                   'basin3d/plugins/mapping_usgs.csv'],
       include_package_data=True,
-      install_requires=[
-         "pandas",
-         "pyyaml",
-         "requests",
-         "tinydb"
-      ]
+      install_requires=required
       )

--- a/tests/test_core_models.py
+++ b/tests/test_core_models.py
@@ -2,9 +2,10 @@ import pytest
 
 from basin3d.core.models import AbsoluteCoordinate, AltitudeCoordinate, Coordinate, DepthCoordinate, \
     GeographicCoordinate, MeasurementTimeseriesTVPObservation, MonitoringFeature, Observation, ObservedProperty, \
-    ObservedPropertyVariable, RelatedSamplingFeature, RepresentativeCoordinate, ResultQuality, TimeValuePair, \
+    ObservedPropertyVariable, RelatedSamplingFeature, RepresentativeCoordinate, TimeValuePair, \
     VerticalCoordinate, DataSource
-from basin3d.core.types import FeatureTypes, SamplingMedium, SpatialSamplingShapes
+from basin3d.core.schema.enum import FeatureTypeEnum, ResultQualityEnum
+from basin3d.core.types import SamplingMedium, SpatialSamplingShapes
 
 
 @pytest.fixture
@@ -79,12 +80,12 @@ def test_related_sampling_feature(plugin_access_alpha):
     """Test a Related Sampling feature"""
     related_sampling_feature = RelatedSamplingFeature(plugin_access=plugin_access_alpha,
                                                       related_sampling_feature='Region1',
-                                                      related_sampling_feature_type=FeatureTypes.REGION,
+                                                      related_sampling_feature_type=FeatureTypeEnum.REGION,
                                                       role=RelatedSamplingFeature.ROLE_PARENT)
 
     assert related_sampling_feature.datasource == plugin_access_alpha.datasource
     assert related_sampling_feature.related_sampling_feature == 'A-Region1'
-    assert related_sampling_feature.related_sampling_feature_type == FeatureTypes.REGION
+    assert related_sampling_feature.related_sampling_feature_type == FeatureTypeEnum.REGION
     assert related_sampling_feature.role == RelatedSamplingFeature.ROLE_PARENT
 
 
@@ -107,7 +108,7 @@ def test_monitoring_feature_create(plugin_access_alpha):
         id="Region1",
         name="AwesomeRegion",
         description="This region is really awesome.",
-        feature_type=FeatureTypes.REGION,
+        feature_type=FeatureTypeEnum.REGION,
         shape=SpatialSamplingShapes.SHAPE_SURFACE,
         coordinates=Coordinate(representative=RepresentativeCoordinate(
             representative_point=AbsoluteCoordinate(
@@ -124,7 +125,7 @@ def test_monitoring_feature_create(plugin_access_alpha):
     assert a_region.datasource.id == 'Alpha'
     assert a_region.id == 'A-Region1'
     assert a_region.name == 'AwesomeRegion'
-    assert a_region.feature_type == FeatureTypes.REGION
+    assert a_region.feature_type == FeatureTypeEnum.REGION
     assert a_region.description == 'This region is really awesome.'
     assert a_region.shape == SpatialSamplingShapes.SHAPE_SURFACE
     assert a_region.coordinates.representative.representative_point.horizontal_position[0].units == \
@@ -144,7 +145,7 @@ def test_monitoring_feature_create(plugin_access_alpha):
         id='1',
         name='Point Location 1',
         description='The first point.',
-        feature_type=FeatureTypes.POINT,
+        feature_type=FeatureTypeEnum.POINT,
         shape=SpatialSamplingShapes.SHAPE_POINT,
         coordinates=Coordinate(
             absolute=AbsoluteCoordinate(
@@ -165,14 +166,14 @@ def test_monitoring_feature_create(plugin_access_alpha):
         related_sampling_feature_complex=[
             RelatedSamplingFeature(plugin_access=plugin_access_alpha,
                                    related_sampling_feature='Region1',
-                                   related_sampling_feature_type=FeatureTypes.REGION,
+                                   related_sampling_feature_type=FeatureTypeEnum.REGION,
                                    role=RelatedSamplingFeature.ROLE_PARENT)]
     )
 
     assert a_point.datasource.id == 'Alpha'
     assert a_point.id == 'A-1'
     assert a_point.name == 'Point Location 1'
-    assert a_point.feature_type == FeatureTypes.POINT
+    assert a_point.feature_type == FeatureTypeEnum.POINT
     assert a_point.description == 'The first point.'
     assert a_point.shape == SpatialSamplingShapes.SHAPE_POINT
     assert a_point.coordinates.absolute.horizontal_position[0].units == \
@@ -204,7 +205,7 @@ def test_observation_create(plugin_access_alpha):
         id='timeseries01',
         utc_offset='9',
         phenomenon_time='20180201',
-        result_quality=ResultQuality().RESULT_QUALITY_CHECKED,
+        result_quality=ResultQualityEnum.CHECKED,
         feature_of_interest='Point011')
 
     assert obs01.datasource.id == 'Alpha'
@@ -212,7 +213,7 @@ def test_observation_create(plugin_access_alpha):
     assert obs01.utc_offset == '9'
     assert obs01.phenomenon_time == '20180201'
     assert obs01.observed_property is None
-    assert obs01.result_quality == ResultQuality().RESULT_QUALITY_CHECKED
+    assert obs01.result_quality == ResultQualityEnum.CHECKED
     assert obs01.feature_of_interest == 'Point011'
 
 
@@ -224,9 +225,9 @@ def test_measurement_timeseries_tvp_observation_create(plugin_access_alpha):
         id='timeseries01',
         utc_offset='9',
         phenomenon_time='20180201',
-        result_quality=ResultQuality().RESULT_QUALITY_CHECKED,
+        result_quality=ResultQualityEnum.CHECKED,
         feature_of_interest='Point011',
-        feature_of_interest_type=FeatureTypes.POINT,
+        feature_of_interest_type=FeatureTypeEnum.POINT,
         aggregation_duration='daily',
         time_reference_position='start',
         observed_property_variable='Acetate',
@@ -249,9 +250,9 @@ def test_measurement_timeseries_tvp_observation_create(plugin_access_alpha):
             location='https://asource.foo/', credentials={}),
         datasource_description='')
     assert obs01.observed_property_variable == 'ACT'
-    assert obs01.result_quality == ResultQuality.RESULT_QUALITY_CHECKED
+    assert obs01.result_quality == ResultQualityEnum.CHECKED
     assert obs01.feature_of_interest == 'Point011'
-    assert obs01.feature_of_interest_type == FeatureTypes.POINT
+    assert obs01.feature_of_interest_type == FeatureTypeEnum.POINT
     assert obs01.aggregation_duration == 'daily'
     assert obs01.time_reference_position == 'start'
     assert obs01.statistic == 'mean'

--- a/tests/test_core_plugins.py
+++ b/tests/test_core_plugins.py
@@ -1,4 +1,3 @@
-from collections.abc import Iterator
 from unittest.mock import Mock
 
 import pytest
@@ -7,7 +6,7 @@ import basin3d
 from basin3d.core.catalog import CatalogTinyDb
 from basin3d.core.models import MonitoringFeature
 from basin3d.core.plugin import get_feature_type
-from basin3d.core.types import FeatureTypes
+from basin3d.core.schema.enum import FeatureTypeEnum
 
 
 def test_plugin_metadata():
@@ -74,21 +73,8 @@ def test_plugin_views(monkeypatch):
     assert basin3d.core.models.MonitoringFeature in plugin_views
 
 
-def test_plugin_view_list_monitoring_feature(monkeypatch, datasource):
-    """Import the alpha plugin and try to list data from a view"""
-    from tests.testplugins import alpha
-    catalog = CatalogTinyDb()
-    plugin = alpha.AlphaSourcePlugin(catalog)
-    catalog.initialize([plugin])
-    for access_class in alpha.AlphaSourcePlugin.plugin_access_classes:
-        generator = access_class(datasource, catalog).list()
-        assert isinstance(generator, Iterator)
-        for v in generator:
-            isinstance(v, MonitoringFeature)
-
-
 @pytest.mark.parametrize("feature_name, return_format, result", [("FOO", None, None),
-                                                                 ("REGION", "enum", FeatureTypes.REGION),
+                                                                 ("REGION", "enum", FeatureTypeEnum.REGION),
                                                                  ("REGION", None, "REGION")],
                          ids=["nonexistent", "return_enum", "return_string"])
 def test_get_feature_type(feature_name, return_format, result):

--- a/tests/test_core_schema.py
+++ b/tests/test_core_schema.py
@@ -1,0 +1,106 @@
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from basin3d.core.schema.enum import FeatureTypeEnum, ResultQualityEnum, StatisticEnum, TimeFrequencyEnum
+from basin3d.core.schema.query import QueryMeasurementTimeseriesTVP, QueryMonitoringFeature
+
+
+@pytest.mark.parametrize("params, error", [({}, False),
+                                           ({"datasource": ["FOO"],
+                                             "monitoring_features": []}, False),
+                                           ({"datasource": ["FOO"],
+                                             "monitoring_features": ['bar', 'base'],
+                                             "parent_features": ['moo']}, False),
+                                           ({"feature_type": 'POINT'}, False),
+                                           ({"feature_type": 'FOO'}, True),
+                                           ({"datasource": 'FOO'}, False)],
+                         ids=["empty", "valid1", "valid2", "feature-type-valid", "feature-type-invalid",
+                              "datasource-invalid"])
+def test_query_monitoring_feature(params, error):
+    """Test the monitoring feature query dataclass"""
+    if not error:
+        query = QueryMonitoringFeature(**params)
+
+        for p in ["datasource", "monitoring_features", "parent_features",
+                  "feature_type"]:
+
+            if p not in params:
+                assert getattr(query, p) is None
+            else:
+                assert getattr(query, p) == params[p] or getattr(query, p) == [params[p]]
+    else:
+        pytest.raises(ValidationError, QueryMonitoringFeature, **params)
+
+
+@pytest.mark.parametrize("params, error", [({}, True),
+                                           ({"datasource": ["FOO"],
+                                             "monitoring_features": [],
+                                             "aggregation_duration": 'MONTH',
+                                             "observed_property_variables":['FOO', 'BAR'],
+                                             "start_date": "2021-01-01"}, True),
+                                           ({"datasource": ["FOO"],
+                                             "monitoring_features": [],
+                                             "aggregation_duration": 'MONTH',
+                                             "start_date": "2021-01-01"}, True),
+                                           ({"datasource": ["FOO"],
+                                             "monitoring_features": ['bar', 'base'],
+                                             "aggregation_duration": 'MONTH',
+                                             "observed_property_variables":['FOO', 'BAR'],
+                                             "start_date": "2021-01-01"}, False),
+                                           ({"aggregation_duration": 'FOO',
+                                             "monitoring_features": ['bar', 'base'],
+                                             "observed_property_variables":['FOO', 'BAR'],
+                                             "start_date": "2021-01-01"}, True),
+                                           ({"statistic": ['MEAN'],
+                                             "monitoring_features": ['bar', 'base'],
+                                             "aggregation_duration": 'MONTH',
+                                             "observed_property_variables":['FOO', 'BAR'],
+                                             "start_date": "2021-01-01"}, False),
+                                           ({"result_quality": 'CHECKED',
+                                             "monitoring_features": ['bar', 'base'],
+                                             "aggregation_duration": 'MONTH',
+                                             "observed_property_variables":['FOO', 'BAR'],
+                                             "start_date": "2021-01-01"}, False),
+                                           ({"statistic": ['FOO'],
+                                             "monitoring_features": ['bar', 'base'],
+                                             "aggregation_duration": 'MONTH',
+                                             "observed_property_variables":['FOO', 'BAR'],
+                                             "start_date": "2021-01-01"}, True),
+                                           ({"result_quality": 'BAR',
+                                             "monitoring_features": ['bar', 'base'],
+                                             "aggregation_duration": 'MONTH',
+                                             "observed_property_variables":['FOO', 'BAR'],
+                                             "start_date": "2021-01-01"}, True)],
+                         ids=["empty-invalid", "monitoring-feature-invalid", "observed-property-variables-missing", "valid1",
+                              "aggregation-duration-invalid",
+                              "statistic-valid", "result-quality-valid",
+                              "statistic-invalid", "result-quality-invalid"])
+def test_query_measurement_timeseries_tvp(params, error):
+    """Test the measurement timeseries tvp query dataclass"""
+    if not error:
+        query = QueryMeasurementTimeseriesTVP(**params)
+
+        for p in ["datasource", "aggregation_duration", "monitoring_features", "observed_property_variables",
+                  "start_date", "end_date", "statistic", "result_quality"]:
+
+            query_json = json.loads(query.json())
+            if p not in params:
+                assert query_json[p] is None
+            else:
+                assert query_json[p] == params[p]
+
+            if 'aggregation_duration' not in query_json.keys():
+                assert query_json['aggregation_duration'] == 'DAY'
+
+    else:
+        pytest.raises(ValidationError, QueryMeasurementTimeseriesTVP, **params)
+
+
+@pytest.mark.parametrize("enum", [FeatureTypeEnum, ResultQualityEnum, StatisticEnum, TimeFrequencyEnum])
+def test_enumerations(enum):
+    """Test the BASIN-3D enumerations"""
+
+    assert enum.names()
+    assert enum.values()

--- a/tests/test_core_synthesis.py
+++ b/tests/test_core_synthesis.py
@@ -1,35 +1,15 @@
 import pytest
 
-from basin3d.core.synthesis import extract_id, extract_query_param_ids, filter_query_param_values
-
-
-def test_extract_id():
-    """Test the synthesis of an id to the datasource id"""
-
-    assert extract_id("F-438935") == "438935"
+from basin3d.core.synthesis import _synthesize_query_identifiers
 
 
 @pytest.mark.parametrize("values, filtered_params",
-                         [({"foo": ["F-9237"], "b": "7-i"}, {'foo': ['F-9237']}),
-                          ({"foo": ["F-9237", "R-8e38e8", "F-00000"], "b": "7-i"}, {'foo': ['F-9237', 'F-00000']}),
-                          ({"foo": "R-9237", "b": "7-i"}, {'foo': []})],
-                         ids=["single", "multiple", "none"])
-def test_filter_query_param_values(values, filtered_params):
-    """Filtering of query arguments"""
-
-    query_params = {}
-    filter_query_param_values("foo", "F", query_params, **values)
-    assert query_params == filtered_params
-
-
-@pytest.mark.parametrize("values, filtered_params",
-                         [({"foo": ["F-9237"], "b": "7-i"}, {'foo': ['9237']}),
-                          ({"foo": ["F-9237", "R-8e38e8", "F-00000"], "b": "7-i"}, {'foo': ['9237', '00000']}),
-                          ({"foo": "R-9237", "b": "7-i"}, {'foo': []})],
+                         [(["F-9237"], ['9237']),
+                          (["F-9237", "R-8e38e8", "F-00000"], ['9237', '00000']),
+                          ("R-9237", [])],
                          ids=["single", "multiple", "none"])
 def test_extract_query_param_ids(values, filtered_params):
     """Filtering of query arguments"""
 
-    query_params = {}
-    extract_query_param_ids("foo", "F", query_params, **values)
-    assert query_params == filtered_params
+    synthesized_values = _synthesize_query_identifiers(values, "F")
+    assert synthesized_values == filtered_params


### PR DESCRIPTION
Adds query information to the return to provide more
transparency
  + Adds new schema package for parsing and validating query inputs
    (See basin3d.core.schema.query)
  + Refactors basin3d.core.types used in queries as Enum objects to be
    used in pydantic query schemas (See basin3d.core.schema.enum)
  + Updates requirements.txt with pydantic dependency
  + Refactors classes in basin3d.core.synthesis
     - to use new pydantic schema data classes
     - return new SynthesisResponse object containing information about
       the original query.
  + Refactors tests for the described changes

Closes #96

## Type of change
Although this is a breaking change, the api call that outputs HDF files should not be affected

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How Has This Been Tested?

- [X] Unit tests
- [X] Integration tests 
- [X] Test coverage >= 90%
- [X] Flake8 Tests 
- [X] Mypy Tests 

### Test Configuration
* Python Version: 3.8

## PR Self Evaluation
strikethrough things that don’t make sense for your PR

- [X] My code follows the agreed upon best practices
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests or modified existing tests that prove my fix is effective or that my feature works
- [X] Existing unit tests pass locally with my changes
- ~Any dependent changes have been merged and published in the appropriate modules~
- [X] I have performed a self-review of my own code

