### PR TITLE
Refactor get_timeseries data to support hi res

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --ignore=E501,E701,E126,W504,W292
     - name: Static type checking with mypy
       run: |
         mypy -p basin3d  --python-version ${{ matrix.python-version }}

--- a/basin3d/core/synthesis.py
+++ b/basin3d/core/synthesis.py
@@ -428,7 +428,5 @@ class MeasurementTimeseriesTVPObservationAccess(DataSourceModelAccess):
                 synthesized_query.observed_property_variables = [o.datasource_variable for o in
                                                                  plugin_access.get_observed_properties(
                                                                      query.observed_property_variables)]
-        # Override Aggregation to always be DAY
-        synthesized_query.aggregation_duration = TimeFrequencyEnum.DAY
 
         return synthesized_query


### PR DESCRIPTION
Currently get_timeseries_data can only handle dates and not timestamps
with utc offsets. In order the support instananeous values we need to
remove the timezone information from the timeseries timestamps and
assume local time for the monitoring feature. The git diff below shows a
proof of concept for this implementation.

Closes #131

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests
- [ ] Integration tests 
- [x] Test coverage >= 90%
- [x] Flake8 Tests 
- [x] Mypy Tests 
- [ ] Other - <describe manual tests for the reviewer>

### Test Configuration
* Python Version:

## PR Self Evaluation
strikethrough things that don’t make sense for your PR

- [ ] My code follows the agreed upon best practices
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests or modified existing tests that prove my fix is effective or that my feature works
- [ ] Existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in the appropriate modules
- [ ] I have performed a self-review of my own code

