### PR TITLE
DataSourceModelAccess.retrieve and related updates

### DIFF
--- a/basin3d/core/plugin.py
+++ b/basin3d/core/plugin.py
@@ -91,7 +91,7 @@ def basin3d_plugin(cls):
     return cls
 
 
-def basin3d_plugin_access(plugin_class, synthesis_model_class, access_type):
+def _basin3d_plugin_access(plugin_class, synthesis_model_class, access_type):
     """Decorator for registering model access"""
 
     def _inner(func):

--- a/basin3d/core/schema/query.py
+++ b/basin3d/core/schema/query.py
@@ -36,6 +36,9 @@ class QueryBase(BaseModel):
 
     datasource: Optional[List[str]] = Field(title="Datasource Identifiers",
                                             description="List of datasource identifiers to query by.")
+
+    id: Optional[str] = Field(title="Identifier", description="The unique identifier for the desired object")
+
     is_valid_translated_query: Union[None, bool] = Field(default=None, title="Valid translated query",
                                                          description="Indicates whether the translated query is valid: None = is not translated")
 
@@ -68,14 +71,9 @@ class QueryBase(BaseModel):
     prefixed_fields: ClassVar[List[str]] = []
 
 
-class QueryById(QueryBase):
-    """Query for a single data object by identifier"""
-
-    id: str = Field(title="Identifier", description="The unique identifier for the desired data object")
-
-
 class QueryMonitoringFeature(QueryBase):
     """Query :class:`basin3d.core.models.MonitoringFeature`"""
+    # optional but id (QueryBase) is required to query by named monitoring feature
     feature_type: Optional[FeatureTypeEnum] = Field(title="Feature Type",
                                                     description="Filter results by the specified feature type.")
     monitoring_feature: Optional[List[str]] = Field(title="Monitoring Features",
@@ -101,7 +99,7 @@ class QueryMonitoringFeature(QueryBase):
                 data[field] = isinstance(data[field], str) and data[field].upper() or data[field]
         super().__init__(**data)
 
-    prefixed_fields: ClassVar[List[str]] = ['monitoring_feature', 'parent_feature']
+    prefixed_fields: ClassVar[List[str]] = ['id', 'monitoring_feature', 'parent_feature']
 
 
 class QueryMeasurementTimeseriesTVP(QueryBase):

--- a/basin3d/synthesis.py
+++ b/basin3d/synthesis.py
@@ -35,8 +35,7 @@ from typing import List, Union, cast
 from basin3d.core.catalog import CatalogTinyDb
 from basin3d.core.models import DataSource
 from basin3d.core.plugin import PluginMount
-from basin3d.core.schema.query import QueryById, QueryMeasurementTimeseriesTVP, \
-    QueryMonitoringFeature, SynthesisResponse
+from basin3d.core.schema.query import QueryMeasurementTimeseriesTVP, QueryMonitoringFeature, SynthesisResponse
 from basin3d.core.synthesis import DataSourceModelIterator, MeasurementTimeseriesTVPObservationAccess, \
     MonitoringFeatureAccess, logger
 
@@ -183,7 +182,7 @@ class DataSynthesizer:
         """
         return self._catalog.find_attribute_mappings(datasource_id=datasource_id, attr_type=attr_type, attr_vocab=attr_vocab, from_basin3d=from_basin3d)
 
-    def monitoring_features(self, query: Union[QueryById, QueryMonitoringFeature] = None, **kwargs) -> Union[
+    def monitoring_features(self, query: QueryMonitoringFeature = None, **kwargs) -> Union[
             DataSourceModelIterator, SynthesisResponse]:
         """
         Search for all USGS monitoring features, USGS points by parent monitoring features, or look for a single monitoring feature by id.
@@ -246,13 +245,10 @@ class DataSynthesizer:
             or a :class:`~basin3d.core.synthesis.DataSourceModelIterator` for multple :class:`MonitoringFeature` objects.
         """
         if not query:
-            if "id" in kwargs and isinstance(kwargs["id"], str):
-                query = QueryById(**kwargs)
-            else:
-                query = QueryMonitoringFeature(**kwargs)
+            query = QueryMonitoringFeature(**kwargs)
 
         # Search for single or list?
-        if isinstance(query, QueryById):
+        if query.id:
             #  mypy casts are only used as hints for the type checker,
             #  and they don’t perform a runtime type check.
             return cast(SynthesisResponse, self._monitoring_feature_access.retrieve(query=query))

--- a/tests/test_core_plugins.py
+++ b/tests/test_core_plugins.py
@@ -35,9 +35,9 @@ def test_plugin_access_objects():
         basin3d.core.models.MonitoringFeature]
 
     assert plugin_access_objects[
-               basin3d.core.models.MonitoringFeature].__class__.__name__ == 'tests.testplugins.alpha.AlphaMonitoringFeatureAccess'
+               basin3d.core.models.MonitoringFeature].__class__.__name__ == 'AlphaMonitoringFeatureAccess'
     assert plugin_access_objects[basin3d.core.models.MeasurementTimeseriesTVPObservation].__class__.__name__ == \
-           'tests.testplugins.alpha.AlphaMeasurementTimeseriesTVPObservationAccess'
+           'AlphaMeasurementTimeseriesTVPObservationAccess'
 
 
 def test_plugin_incomplete():
@@ -99,13 +99,13 @@ def test_get_feature_type(feature_name, return_format, result):
      {'start_date': '2019-10-01', 'observed_property': ["Ag"], 'monitoring_feature': ['E-region']}),
     # AlphaSource.MF
     ("tests.testplugins.alpha.AlphaSourcePlugin",
-     [{'level': 'ERROR', 'msg': 'DataSource not not found for id E-1234', 'where': None}],
+     [{'level': 'ERROR', 'msg': 'DataSource not found for retrieve request', 'where': None}],
      "monitoring_features",
      {"id": 'E-1234'}),
-    # USGS.MR
+    # USGS.MF
 
     ("basin3d.plugins.usgs.USGSDataSourcePlugin",
-     [{'level': 'ERROR', 'msg': 'DataSource not not found for id E-1234', 'where': None}],
+     [{'level': 'ERROR', 'msg': 'DataSource not found for retrieve request', 'where': None}],
      "monitoring_features",
      {"id": 'E-1234'}),
     # NoPluginViews.TVP
@@ -124,7 +124,7 @@ def test_get_feature_type(feature_name, return_format, result):
      "measurement_timeseries_tvp_observations",
      {'start_date': '2019-10-01', 'observed_property': ["Ag"], 'monitoring_feature': ['A-region']}),
     ],
-    ids=["ErrorSource.MF", "ErrorSource.TVP", "AlphaSource.MF", "USGS.MR", "NoPluginViews.TVP", "NoPluginViews.MF", "AlphaSource.TVP"])
+    ids=["ErrorSource.MF", "ErrorSource.TVP", "AlphaSource.MF", "USGS.MF", "NoPluginViews.TVP", "NoPluginViews.MF", "AlphaSource.TVP"])
 def test_plugin_exceptions(plugin, messages, synthesis_call, synthesis_args):
     """Test that basin3d handles unexpected exceptions"""
 

--- a/tests/test_core_schema.py
+++ b/tests/test_core_schema.py
@@ -15,16 +15,18 @@ from basin3d.core.schema.query import QueryMeasurementTimeseriesTVP, QueryMonito
                                              "parent_feature": ['moo']}, False),
                                            ({"feature_type": 'POINT'}, False),
                                            ({"feature_type": 'FOO'}, True),
-                                           ({"datasource": 'FOO'}, False)],
+                                           ({"datasource": 'FOO'}, False),
+                                           ({"id": 'foo'}, False),
+                                           ({"id": ['foo']}, True)],
                          ids=["empty", "valid1", "valid2", "feature-type-valid", "feature-type-invalid",
-                              "datasource-invalid"])
+                              "datasource-invalid", "id-valid", "id-invalid"])
 def test_query_monitoring_feature(params, error):
     """Test the monitoring feature query dataclass"""
     if not error:
         query = QueryMonitoringFeature(**params)
 
         for p in ["datasource", "monitoring_feature", "parent_feature",
-                  "feature_type"]:
+                  "feature_type", "id"]:
 
             if p not in params:
                 assert getattr(query, p) is None
@@ -98,7 +100,7 @@ def test_query_measurement_timeseries_tvp(params, error):
         query = QueryMeasurementTimeseriesTVP(**params)
 
         for p in ["datasource", "aggregation_duration", "monitoring_feature", "observed_property",
-                  "start_date", "end_date", "statistic", "result_quality"]:
+                  "start_date", "end_date", "statistic", "result_quality", "id"]:
 
             query_json = json.loads(query.json())
             if p not in params:

--- a/tests/test_core_synthesis.py
+++ b/tests/test_core_synthesis.py
@@ -1,9 +1,9 @@
 import pytest
 
-from basin3d.core.models import DataSource
+from basin3d.core.models import DataSource, MonitoringFeature
 from basin3d.core.plugin import DataSourcePluginAccess
-from basin3d.core.schema.query import QueryMeasurementTimeseriesTVP
-from basin3d.core.synthesis import MeasurementTimeseriesTVPObservationAccess
+from basin3d.core.schema.query import QueryMeasurementTimeseriesTVP, QueryMonitoringFeature
+from basin3d.core.synthesis import MeasurementTimeseriesTVPObservationAccess, MonitoringFeatureAccess, SynthesisResponse
 
 from tests.testplugins import alpha
 
@@ -42,3 +42,18 @@ def test_measurement_timeseries_TVP_observation_access_synthesize_query(input_qu
     result = alpha_access.synthesize_query(alpha_plugin_access, query)
 
     assert result.aggregation_duration == expected_result
+
+
+def test_monitoring_feature_retrieve_no_id():
+    from basin3d.core.catalog import CatalogTinyDb
+    catalog = CatalogTinyDb()
+    catalog.initialize([p(catalog) for p in [alpha.AlphaSourcePlugin]])
+    alpha_ds = DataSource(id='Alpha', name='Alpha', id_prefix='A', location='https://asource.foo/')
+    # cheating and assigning a datasource to the plugin field as it won't be used
+    alpha_access = MonitoringFeatureAccess({'A': alpha_ds}, catalog)
+
+    result = alpha_access.retrieve(query=QueryMonitoringFeature())
+
+    assert isinstance(result, SynthesisResponse)
+    assert result.data is None
+    assert result.messages[0].msg == 'query.id field is missing and is required for monitoring feature request by id.'

--- a/tests/test_core_translate.py
+++ b/tests/test_core_translate.py
@@ -200,8 +200,8 @@ def test_translator_is_translated_query_valid(query, set_translated_attr, expect
                            {'monitoring_feature': ['9237', '00000']}),
                           (QueryMeasurementTimeseriesTVP(monitoring_feature=['F-9237'], observed_property=['Ag'], start_date='2019-01-01'),
                            {'monitoring_feature': []}),
-                          (QueryMonitoringFeature(monitoring_feature=['A-9237', 'R-8e3838'], parent_feature=['A-00000']),
-                           {'monitoring_feature': ['9237'], 'parent_feature': ['00000']}),
+                          (QueryMonitoringFeature(monitoring_feature=['A-9237', 'R-8e3838'], parent_feature=['A-00000'], id='A-345aa'),
+                           {'monitoring_feature': ['9237'], 'parent_feature': ['00000'], 'id': '345aa'}),
                           ],
                          ids=["single", "multiple", "none", "monitoring_feature_query"])
 def test_translator_prefixed_query_attrs(alpha_plugin_access, query, set_translated_attr):

--- a/tests/testplugins/alpha.py
+++ b/tests/testplugins/alpha.py
@@ -4,16 +4,257 @@ from typing import Any, List
 from basin3d.core.models import AbsoluteCoordinate, AltitudeCoordinate, Coordinate, DepthCoordinate, \
     GeographicCoordinate, MeasurementTimeseriesTVPObservation, MonitoringFeature, RelatedSamplingFeature, \
     RepresentativeCoordinate, SpatialSamplingShapes, VerticalCoordinate, ResultListTVP
-from basin3d.core.plugin import DataSourcePluginPoint, basin3d_plugin, basin3d_plugin_access
+from basin3d.core.plugin import DataSourcePluginPoint, basin3d_plugin, DataSourcePluginAccess
 from basin3d.core.schema.enum import FeatureTypeEnum, TimeFrequencyEnum
-from basin3d.core.schema.query import QueryById, QueryMeasurementTimeseriesTVP, QueryMonitoringFeature
+from basin3d.core.schema.query import QueryMeasurementTimeseriesTVP, QueryMonitoringFeature
 
 logger = logging.getLogger(__name__)
+
+
+class AlphaMeasurementTimeseriesTVPObservationAccess(DataSourcePluginAccess):
+    """
+    Alpha Measurement TVP Observation Access
+    """
+    synthesis_model_class = MeasurementTimeseriesTVPObservation
+
+    def list(self, query: QueryMeasurementTimeseriesTVP):
+        """ Generate the MeasurementTimeseriesTVPObservation
+
+          Attributes:
+            - *id:* string, Cs137 MR survey ID
+            - *observed_property:* string, Cs137MID
+            - *utc_offset:* float (offset in hours), +9
+            - *geographical_group_id:* string, River system ID (Region ID).
+            - *geographical_group_type* enum (sampling_feature, site, plot, region)
+            - *results_points:* Array of DataPoint objects
+
+        """
+        synthesis_messages: List[str] = []
+        data: List[Any] = []
+        quality: List[Any] = []
+
+        if query.monitoring_feature == ['region']:
+            return StopIteration({"message": "FOO"})
+
+        supported_monitoring_features = [f'{num}' for num in range(1, 5)]
+
+        if not any([loc_id in supported_monitoring_features for loc_id in query.monitoring_feature]):
+            return StopIteration({"message": "No data from data source matches monitoring features specified."})
+
+        location_indices = []
+        for loc_id in query.monitoring_feature:
+            if loc_id in supported_monitoring_features:
+                location_indices.append(int(loc_id.split('-')[-1]))
+
+        from datetime import datetime
+        for num in range(1, 10):
+            data.append((datetime(2016, 2, num), num * 0.3454))
+        data = [data, data, [], data]
+        rqe1 = 'VALIDATED'
+        rqe2 = 'UNVALIDATED'
+        rqe3 = 'REJECTED'
+        quality = [[rqe1, rqe1, rqe1, rqe1, rqe1, rqe1, rqe1, rqe1, rqe1],
+                   [rqe2, rqe2, rqe2, rqe2, rqe2, rqe2, rqe2, rqe3, rqe3],
+                   [],
+                   [rqe1, rqe2, rqe3, rqe1, rqe1, rqe1, rqe1, rqe1, rqe1]]
+        qualities = [[rqe1],
+                     [rqe2, rqe3],
+                     [],
+                     [rqe1, rqe2, rqe3]]
+        observed_property_variables = ["Acetate", "Acetate", "Aluminum", "Al"]
+        units = ['nm', 'nm', 'mg/L', 'mg/L']
+        statistics = ['mean', 'max', 'mean', 'max']
+
+        for num in location_indices:
+            observed_property_variable = observed_property_variables[num - 1]
+            feature_id = f'A-{str(num - 1)}'
+            if query:
+                if observed_property_variable not in query.observed_property:
+                    continue
+                if query.statistic:
+                    if statistics[num - 1] not in query.statistic:
+                        continue
+                result_value = data[num - 1]
+                result_value_quality = quality[num - 1]
+                result_qualities = qualities[num - 1]
+                if query.result_quality:
+                    filtered_value = []
+                    filtered_quality = []
+                    has_filtered_data_points = 0
+
+                    for v, q in zip(result_value, result_value_quality):
+                        if q in query.result_quality:
+                            filtered_value.append(v)
+                            filtered_quality.append(q)
+                        else:
+                            has_filtered_data_points += 1
+
+                    if has_filtered_data_points > 0:
+                        synthesis_messages.append(f'{feature_id} - {observed_property_variable}: {str(has_filtered_data_points)} timestamps did not match data quality query.')
+
+                    if len(filtered_value) == 0:
+                        synthesis_messages.append(f'{feature_id} - {observed_property_variable}: No data values matched result_quality query.')
+                        print(f'{feature_id} - {observed_property_variable}')
+                        continue
+
+                    result_value = filtered_value
+                    result_value_quality = filtered_quality
+                    if len(result_value_quality) > 0:
+                        result_qualities = list(set(result_value_quality))
+                    else:
+                        result_qualities = []
+
+            yield MeasurementTimeseriesTVPObservation(
+                plugin_access=self,
+                id=num,
+                observed_property=observed_property_variable,
+                utc_offset=-8 - num,
+                feature_of_interest=MonitoringFeature(
+                    plugin_access=self,
+                    id=num,
+                    name="Point Location " + str(num),
+                    description="The point.",
+                    feature_type=FeatureTypeEnum.POINT,
+                    shape=SpatialSamplingShapes.SHAPE_POINT,
+                    coordinates=Coordinate(
+                        absolute=AbsoluteCoordinate(
+                            horizontal_position=GeographicCoordinate(
+                                units=GeographicCoordinate.UNITS_DEC_DEGREES,
+                                latitude=70.4657, longitude=-20.4567),
+                            vertical_extent=AltitudeCoordinate(
+                                datum=AltitudeCoordinate.DATUM_NAVD88,
+                                value=1500,
+                                distance_units=VerticalCoordinate.DISTANCE_UNITS_FEET)),
+                        representative=RepresentativeCoordinate(
+                            vertical_position=DepthCoordinate(
+                                datum=DepthCoordinate.DATUM_LOCAL_SURFACE,
+                                value=-0.5 - num * 0.1,
+                                distance_units=VerticalCoordinate.DISTANCE_UNITS_METERS)
+                        )
+                    ),
+                    observed_properties=["Ag", "Acetate", "Aluminum", "Al"],
+                    related_sampling_feature_complex=[
+                        RelatedSamplingFeature(plugin_access=self,
+                                               related_sampling_feature="Region1",
+                                               related_sampling_feature_type=FeatureTypeEnum.REGION,
+                                               role=RelatedSamplingFeature.ROLE_PARENT)]
+                ),
+                feature_of_interest_type=FeatureTypeEnum.POINT,
+                unit_of_measurement=units[num - 1],
+                aggregation_duration=TimeFrequencyEnum.DAY,
+                result_quality=result_qualities,
+                time_reference_position=None,
+                statistic=statistics[num - 1],
+                result=ResultListTVP(plugin_access=self, value=result_value, result_quality=result_value_quality)
+            )
+
+        return StopIteration(synthesis_messages)
+
+
+class AlphaMonitoringFeatureAccess(DataSourcePluginAccess):
+    """
+    Alpha Monitoring Feature Access Plugin
+    """
+    synthesis_model_class = MonitoringFeature
+
+    def list(self, query: QueryMonitoringFeature):
+        """
+        Get Monitoring Feature Info
+        """
+        assert query
+
+        monitoring_feature_list = query.monitoring_feature
+        feature_type = query.feature_type
+
+        obj_region = self.synthesis_model_class(
+            plugin_access=self,
+            id="Region1",
+            name="AwesomeRegion",
+            description="This region is really awesome.",
+            feature_type=FeatureTypeEnum.REGION,
+            shape=SpatialSamplingShapes.SHAPE_SURFACE,
+            coordinates=Coordinate(representative=RepresentativeCoordinate(
+                representative_point=AbsoluteCoordinate(
+                    horizontal_position=GeographicCoordinate(
+                        units=GeographicCoordinate.UNITS_DEC_DEGREES,
+                        latitude=70.4657, longitude=-20.4567),
+                    vertical_extent=AltitudeCoordinate(
+                        datum=AltitudeCoordinate.DATUM_NAVD88,
+                        value=1500,
+                        distance_units=VerticalCoordinate.DISTANCE_UNITS_FEET)),
+                representative_point_type=RepresentativeCoordinate.REPRESENTATIVE_POINT_TYPE_CENTER_LOCAL_SURFACE)
+            )
+        )
+
+        if monitoring_feature_list and 'Region1' in monitoring_feature_list:
+            if feature_type == FeatureTypeEnum.REGION:
+                yield obj_region
+        elif feature_type == FeatureTypeEnum.REGION:
+            yield obj_region
+
+        obj_point = self.synthesis_model_class(
+            plugin_access=self,
+            id="1",
+            name="Point Location 1",
+            description="The first point.",
+            feature_type=FeatureTypeEnum.POINT,
+            shape=SpatialSamplingShapes.SHAPE_POINT,
+            coordinates=Coordinate(
+                absolute=AbsoluteCoordinate(
+                    horizontal_position=GeographicCoordinate(
+                        units=GeographicCoordinate.UNITS_DEC_DEGREES,
+                        latitude=70.4657, longitude=-20.4567),
+                    vertical_extent=AltitudeCoordinate(
+                        datum=AltitudeCoordinate.DATUM_NAVD88,
+                        value=1500,
+                        distance_units=VerticalCoordinate.DISTANCE_UNITS_FEET)),
+                representative=RepresentativeCoordinate(
+                    vertical_position=DepthCoordinate(
+                        datum=DepthCoordinate.DATUM_LOCAL_SURFACE,
+                        value=-0.5,
+                        distance_units=VerticalCoordinate.DISTANCE_UNITS_METERS)
+                )
+            ),
+            observed_properties=["Ag", "Acetate"],
+            related_sampling_feature_complex=[
+                RelatedSamplingFeature(plugin_access=self,
+                                       related_sampling_feature="Region1",
+                                       related_sampling_feature_type=FeatureTypeEnum.REGION,
+                                       role=RelatedSamplingFeature.ROLE_PARENT)]
+        )
+
+        if not feature_type or feature_type == FeatureTypeEnum.POINT:
+            if monitoring_feature_list and '1' in monitoring_feature_list:
+                yield obj_point
+            elif not monitoring_feature_list:
+                yield obj_point
+
+        return StopIteration(['message1', 'message2', 'message3'])
+
+    def get(self, query: QueryMonitoringFeature):
+
+        """
+        Get a MonitoringFeature
+        :param query: Monitoring Feature Query
+        """
+        # query.id is a str at this point due to upstream validation, thus the type ignore.
+
+        prefixed_monitoring_feature = f'{self.datasource.id_prefix}-{query.id}'
+
+        # add id to monitoring_feature field
+        query.monitoring_feature = [query.id]  # type: ignore[list-item]
+
+        for s in self.list(query):
+            if s.id == prefixed_monitoring_feature:
+                return s
+
+        return None
 
 
 @basin3d_plugin
 class AlphaSourcePlugin(DataSourcePluginPoint):
     title = 'Alpha Source Plugin'
+    plugin_access_classes = (AlphaMeasurementTimeseriesTVPObservationAccess, AlphaMonitoringFeatureAccess)
 
     # Question: should we use the FeatureTypeEnum CV directly?
     feature_types = ['REGION', 'POINT', 'TREE']
@@ -37,229 +278,3 @@ class AlphaSourcePlugin(DataSourcePluginPoint):
         id = 'Alpha'  # unique id for the datasource
         id_prefix = 'A'
         name = id  # Human Friendly Data Source Name
-
-
-@basin3d_plugin_access(AlphaSourcePlugin, MeasurementTimeseriesTVPObservation, 'list')
-def find_measurement_timeseries_tvp_observations(self, query: QueryMeasurementTimeseriesTVP):
-    """ Generate the MeasurementTimeseriesTVPObservation
-
-      Attributes:
-        - *id:* string, Cs137 MR survey ID
-        - *observed_property:* string, Cs137MID
-        - *utc_offset:* float (offset in hours), +9
-        - *geographical_group_id:* string, River system ID (Region ID).
-        - *geographical_group_type* enum (sampling_feature, site, plot, region)
-        - *results_points:* Array of DataPoint objects
-
-    """
-    synthesis_messages: List[str] = []
-    data: List[Any] = []
-    quality: List[Any] = []
-
-    if query.monitoring_feature == ['region']:
-        return StopIteration({"message": "FOO"})
-
-    supported_monitoring_features = [f'{num}' for num in range(1, 5)]
-
-    if not any([loc_id in supported_monitoring_features for loc_id in query.monitoring_feature]):
-        return StopIteration({"message": "No data from data source matches monitoring features specified."})
-
-    location_indices = []
-    for loc_id in query.monitoring_feature:
-        if loc_id in supported_monitoring_features:
-            location_indices.append(int(loc_id.split('-')[-1]))
-
-    from datetime import datetime
-    for num in range(1, 10):
-        data.append((datetime(2016, 2, num), num * 0.3454))
-    data = [data, data, [], data]
-    rqe1 = 'VALIDATED'
-    rqe2 = 'UNVALIDATED'
-    rqe3 = 'REJECTED'
-    quality = [[rqe1, rqe1, rqe1, rqe1, rqe1, rqe1, rqe1, rqe1, rqe1],
-               [rqe2, rqe2, rqe2, rqe2, rqe2, rqe2, rqe2, rqe3, rqe3],
-               [],
-               [rqe1, rqe2, rqe3, rqe1, rqe1, rqe1, rqe1, rqe1, rqe1]]
-    qualities = [[rqe1],
-                 [rqe2, rqe3],
-                 [],
-                 [rqe1, rqe2, rqe3]]
-    observed_property_variables = ["Acetate", "Acetate", "Aluminum", "Al"]
-    units = ['nm', 'nm', 'mg/L', 'mg/L']
-    statistics = ['mean', 'max', 'mean', 'max']
-
-    for num in location_indices:
-        observed_property_variable = observed_property_variables[num - 1]
-        feature_id = f'A-{str(num - 1)}'
-        if query:
-            if observed_property_variable not in query.observed_property:
-                continue
-            if query.statistic:
-                if statistics[num - 1] not in query.statistic:
-                    continue
-            result_value = data[num - 1]
-            result_value_quality = quality[num - 1]
-            result_qualities = qualities[num - 1]
-            if query.result_quality:
-                filtered_value = []
-                filtered_quality = []
-                has_filtered_data_points = 0
-
-                for v, q in zip(result_value, result_value_quality):
-                    if q in query.result_quality:
-                        filtered_value.append(v)
-                        filtered_quality.append(q)
-                    else:
-                        has_filtered_data_points += 1
-
-                if has_filtered_data_points > 0:
-                    synthesis_messages.append(f'{feature_id} - {observed_property_variable}: {str(has_filtered_data_points)} timestamps did not match data quality query.')
-
-                if len(filtered_value) == 0:
-                    synthesis_messages.append(f'{feature_id} - {observed_property_variable}: No data values matched result_quality query.')
-                    print(f'{feature_id} - {observed_property_variable}')
-                    continue
-
-                result_value = filtered_value
-                result_value_quality = filtered_quality
-                if len(result_value_quality) > 0:
-                    result_qualities = list(set(result_value_quality))
-                else:
-                    result_qualities = []
-
-        yield MeasurementTimeseriesTVPObservation(
-            plugin_access=self,
-            id=num,
-            observed_property=observed_property_variable,
-            utc_offset=-8 - num,
-            feature_of_interest=MonitoringFeature(
-                plugin_access=self,
-                id=num,
-                name="Point Location " + str(num),
-                description="The point.",
-                feature_type=FeatureTypeEnum.POINT,
-                shape=SpatialSamplingShapes.SHAPE_POINT,
-                coordinates=Coordinate(
-                    absolute=AbsoluteCoordinate(
-                        horizontal_position=GeographicCoordinate(
-                            units=GeographicCoordinate.UNITS_DEC_DEGREES,
-                            latitude=70.4657, longitude=-20.4567),
-                        vertical_extent=AltitudeCoordinate(
-                            datum=AltitudeCoordinate.DATUM_NAVD88,
-                            value=1500,
-                            distance_units=VerticalCoordinate.DISTANCE_UNITS_FEET)),
-                    representative=RepresentativeCoordinate(
-                        vertical_position=DepthCoordinate(
-                            datum=DepthCoordinate.DATUM_LOCAL_SURFACE,
-                            value=-0.5 - num * 0.1,
-                            distance_units=VerticalCoordinate.DISTANCE_UNITS_METERS)
-                    )
-                ),
-                observed_properties=["Ag", "Acetate", "Aluminum", "Al"],
-                related_sampling_feature_complex=[
-                    RelatedSamplingFeature(plugin_access=self,
-                                           related_sampling_feature="Region1",
-                                           related_sampling_feature_type=FeatureTypeEnum.REGION,
-                                           role=RelatedSamplingFeature.ROLE_PARENT)]
-            ),
-            feature_of_interest_type=FeatureTypeEnum.POINT,
-            unit_of_measurement=units[num - 1],
-            aggregation_duration=TimeFrequencyEnum.DAY,
-            result_quality=result_qualities,
-            time_reference_position=None,
-            statistic=statistics[num - 1],
-            result=ResultListTVP(plugin_access=self, value=result_value, result_quality=result_value_quality)
-        )
-
-    return StopIteration(synthesis_messages)
-
-
-@basin3d_plugin_access(AlphaSourcePlugin, MeasurementTimeseriesTVPObservation, 'get')
-def get_measurement_timeseries_tvp_observation(self, query: QueryById):
-    """
-        Get a MeasurementTimeseriesTVPObservation
-        :param query:
-    """
-    if query:
-        for s in self.list():
-            if s.id.endswith(query.id):
-                return s
-    return None
-
-
-@basin3d_plugin_access(AlphaSourcePlugin, MonitoringFeature, 'list')
-def list_monitoring_features(self, query: QueryMonitoringFeature):
-    """
-    Get Monitoring Feature Info
-    """
-    assert query
-
-    obj_region = self.synthesis_model_class(
-        plugin_access=self,
-        id="Region1",
-        name="AwesomeRegion",
-        description="This region is really awesome.",
-        feature_type=FeatureTypeEnum.REGION,
-        shape=SpatialSamplingShapes.SHAPE_SURFACE,
-        coordinates=Coordinate(representative=RepresentativeCoordinate(
-            representative_point=AbsoluteCoordinate(
-                horizontal_position=GeographicCoordinate(
-                    units=GeographicCoordinate.UNITS_DEC_DEGREES,
-                    latitude=70.4657, longitude=-20.4567),
-                vertical_extent=AltitudeCoordinate(
-                    datum=AltitudeCoordinate.DATUM_NAVD88,
-                    value=1500,
-                    distance_units=VerticalCoordinate.DISTANCE_UNITS_FEET)),
-            representative_point_type=RepresentativeCoordinate.REPRESENTATIVE_POINT_TYPE_CENTER_LOCAL_SURFACE)
-        )
-    )
-
-    yield obj_region
-
-    obj_point = self.synthesis_model_class(
-        plugin_access=self,
-        id="1",
-        name="Point Location 1",
-        description="The first point.",
-        feature_type=FeatureTypeEnum.POINT,
-        shape=SpatialSamplingShapes.SHAPE_POINT,
-        coordinates=Coordinate(
-            absolute=AbsoluteCoordinate(
-                horizontal_position=GeographicCoordinate(
-                    units=GeographicCoordinate.UNITS_DEC_DEGREES,
-                    latitude=70.4657, longitude=-20.4567),
-                vertical_extent=AltitudeCoordinate(
-                    datum=AltitudeCoordinate.DATUM_NAVD88,
-                    value=1500,
-                    distance_units=VerticalCoordinate.DISTANCE_UNITS_FEET)),
-            representative=RepresentativeCoordinate(
-                vertical_position=DepthCoordinate(
-                    datum=DepthCoordinate.DATUM_LOCAL_SURFACE,
-                    value=-0.5,
-                    distance_units=VerticalCoordinate.DISTANCE_UNITS_METERS)
-            )
-        ),
-        observed_properties=["Ag", "Acetate"],
-        related_sampling_feature_complex=[
-            RelatedSamplingFeature(plugin_access=self,
-                                   related_sampling_feature="Region1",
-                                   related_sampling_feature_type=FeatureTypeEnum.REGION,
-                                   role=RelatedSamplingFeature.ROLE_PARENT)]
-    )
-
-    yield obj_point
-
-    return StopIteration(['message1', 'message2', 'message3'])
-
-
-@basin3d_plugin_access(AlphaSourcePlugin, MonitoringFeature, 'get')
-def get_monitoring_feature(self, query: QueryById):
-    """
-    Get a MonitoringFeature
-    :param pk: primary key
-    """
-    if query:
-        for s in self.list():
-            if s.id.endswith(query.id):
-                return s
-    return None

--- a/tests/testplugins/no_plugin_views.py
+++ b/tests/testplugins/no_plugin_views.py
@@ -1,6 +1,6 @@
 import logging
 
-from basin3d.core.plugin import DataSourcePluginPoint, basin3d_plugin, basin3d_plugin_access
+from basin3d.core.plugin import DataSourcePluginPoint, basin3d_plugin
 
 logger = logging.getLogger(__name__)
 

--- a/tests/testplugins/plugin_error.py
+++ b/tests/testplugins/plugin_error.py
@@ -1,15 +1,58 @@
 import logging
 
 from basin3d.core.models import MeasurementTimeseriesTVPObservation, MonitoringFeature
-from basin3d.core.plugin import DataSourcePluginPoint, basin3d_plugin, basin3d_plugin_access
-from basin3d.core.schema.query import QueryById, QueryMeasurementTimeseriesTVP, QueryMonitoringFeature
+from basin3d.core.plugin import DataSourcePluginPoint, basin3d_plugin, DataSourcePluginAccess
+from basin3d.core.schema.query import QueryMeasurementTimeseriesTVP, QueryMonitoringFeature
 
 logger = logging.getLogger(__name__)
+
+
+class ErrorMeasurementTimeseriesTVPObservationAccess(DataSourcePluginAccess):
+    """
+    MeasurementTimeseriesTVPObservation Access class
+    """
+    synthesis_model_class = MeasurementTimeseriesTVPObservation
+
+    def list(self, query: QueryMeasurementTimeseriesTVP):
+        """ Generate the MeasurementTimeseriesTVPObservation
+
+          Attributes:
+            - *id:* string, Cs137 MR survey ID
+            - *observed_property:* string, Cs137MID
+            - *utc_offset:* float (offset in hours), +9
+            - *geographical_group_id:* string, River system ID (Region ID).
+            - *geographical_group_type* enum (sampling_feature, site, plot, region)
+            - *results_points:* Array of DataPoint objects
+
+        """
+        raise Exception("This is a find_measurement_timeseries_tvp_observations error")
+
+
+class ErrorMonitoringFeatureAccess(DataSourcePluginAccess):
+    """
+    MonitoringFeature Access
+    """
+    synthesis_model_class = MonitoringFeature
+
+    def list(self, query: QueryMonitoringFeature):
+        """
+        Get Monitoring Feature Info
+        :param query:
+        """
+        raise Exception("This is a list_monitoring_features exception")
+
+    def get(self, query: QueryMonitoringFeature):
+        """
+        Get a MonitoringFeature
+        :param query:
+        """
+        raise Exception("This is a get_monitoring_feature exception")
 
 
 @basin3d_plugin
 class ErrorSourcePlugin(DataSourcePluginPoint):
     title = 'Error Source Plugin'
+    plugin_access_classes = (ErrorMonitoringFeatureAccess, ErrorMeasurementTimeseriesTVPObservationAccess)
 
     # Question: should we use the FeatureTypeEnum CV directly?
     feature_types = ['REGION', 'POINT', 'TREE']
@@ -33,45 +76,3 @@ class ErrorSourcePlugin(DataSourcePluginPoint):
         id = 'Error'  # unique id for the datasource
         id_prefix = 'E'
         name = id  # Human Friendly Data Source Name
-
-
-@basin3d_plugin_access(ErrorSourcePlugin, MeasurementTimeseriesTVPObservation, 'list')
-def find_measurement_timeseries_tvp_observations(self, query: QueryMeasurementTimeseriesTVP):
-    """ Generate the MeasurementTimeseriesTVPObservation
-
-      Attributes:
-        - *id:* string, Cs137 MR survey ID
-        - *observed_property:* string, Cs137MID
-        - *utc_offset:* float (offset in hours), +9
-        - *geographical_group_id:* string, River system ID (Region ID).
-        - *geographical_group_type* enum (sampling_feature, site, plot, region)
-        - *results_points:* Array of DataPoint objects
-
-    """
-    raise Exception("This is a find_measurement_timeseries_tvp_observations error")
-
-
-@basin3d_plugin_access(ErrorSourcePlugin, MeasurementTimeseriesTVPObservation, 'get')
-def get_measurement_timeseries_tvp_observation(self, query: QueryById):
-    """
-        Get a MeasurementTimeseriesTVPObservation
-        :param query:
-    """
-    raise Exception("This is a get_measurement_timeseries_tvp_observation error")
-
-
-@basin3d_plugin_access(ErrorSourcePlugin, MonitoringFeature, 'list')
-def list_monitoring_features(self, query: QueryMonitoringFeature):
-    """
-    Get Monitoring Feature Info
-    """
-    raise Exception("This is a list_monitoring_features exception")
-
-
-@basin3d_plugin_access(ErrorSourcePlugin, MonitoringFeature, 'get')
-def get_monitoring_feature(self, query: QueryById):
-    """
-    Get a MonitoringFeature
-    :param pk: primary key
-    """
-    raise Exception("This is a get_monitoring_feature exception")


### PR DESCRIPTION
Update DataSourceModelAccess.retrieve to work properly with the translate layer.

Closes #168

Highlights:
- Add translate logic to DataSourceModelAccess.retrieve method
- Removed QueryById query class and added `id` property to QueryBase
- Added MonitoringFeatureModelAccess.retrieve class to validate specification of `id'
- Updated translation logic of query prefixed_fields and validation of prefixed_fields
- Added tests to explicitly test the retrieve options.
- Removed use of basin3d_plugin_access decorator and made it private b/c a bug was detected. See #170.

Rationale for removing QueryById:
A particular ModelAccess class (e.g., MonitoringFeatureModelAccess) should use the related query class (e.g. QueryMonitoringFeature). In particular, querying by Monitoring Feature id benefits from having the feature_type available as well.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?
- [x] Unit tests
- [x] Integration tests 
- [x] Test coverage >= 90%
- [x] Flake8 Tests 
- [x] Mypy Tests 
- [x] Other - tested with corresponding updates in django-basin3d

### Test Configuration
* Python Version: 3.9

## PR Self Evaluation
- [x] My code follows the agreed upon best practices
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests or modified existing tests that prove my fix is effective or that my feature works
- [x] Existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in the appropriate modules
- [x] I have performed a self-review of my own code

