### PR TITLE
EPA plugin bug causing incorrect MeasTVPObs results in django-basin3d

### DIFF
--- a/basin3d/plugins/epa.py
+++ b/basin3d/plugins/epa.py
@@ -665,7 +665,7 @@ class EPAMeasurementTimeseriesTVPObservationAccess(DataSourcePluginAccess):
         """
         op_map = {}
         for observed_property in observed_properties:
-            attr_mapping: AttributeMapping = get_datasource_mapped_attribute(self, MappedAttributeEnum.OBSERVED_PROPERTY, observed_property)
+            attr_mapping: AttributeMapping = get_datasource_mapped_attribute(self, MappedAttributeEnum.OBSERVED_PROPERTY.value, observed_property)
             basin3d_vocab = attr_mapping.basin3d_vocab
             op_map[observed_property] = basin3d_vocab
 


### PR DESCRIPTION
EPA plugin bug causing incorrect MeasTVPObs results in django-basin3d

Closes #187

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Unit tests
- [x] Integration tests 
- [x] Test coverage >= 90%
- [x] Flake8 Tests 
- [x] Mypy Tests 
- [x] Other: manual comparison of django-basin3d and basin3d results for same query, see forthcoming comments

### Test Configuration
* Python Version: 3.9

## PR Self Evaluation
- [x] My code follows the agreed upon best practices
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
- [x] My changes generate no new warnings
~- [ ] I have added tests or modified existing tests that prove my fix is effective or that my feature works~
- [x] Existing unit tests pass locally with my changes
~- [ ] Any dependent changes have been merged and published in the appropriate modules~
- [x] I have performed a self-review of my own code

