### PR TITLE
fix: bumps up gh action upload-artifact version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,9 @@ jobs:
         python-version: ["3.8", "3.9", "3.10"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -53,7 +53,7 @@ jobs:
         PYTHONPATH=.. make doctest linkcheck html
 
     - name: Archive code coverage results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: code-coverage-report
         path: ${{ github.workspace }}/artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
         PYTHONPATH=.. make doctest linkcheck html
 
     - name: Archive code coverage results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: code-coverage-report
         path: ${{ github.workspace }}/artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,7 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Static type checking with mypy
       run: |
+        mypy --version
         mypy -p basin3d  --python-version ${{ matrix.python-version }}
     - name: Make artifact directory
       run: |

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
 

--- a/basin3d/core/plugin.py
+++ b/basin3d/core/plugin.py
@@ -212,7 +212,7 @@ class PluginMount(type):
     The idea for the Simple Plugin Framework comes from a post
     by Marty Alchin on January 10, 2008 about Django
 
-    See: http://martyalchin.com/2008/jan/10/simple-plugin-framework/
+    See: https://web.archive.org/web/20220506163033/http://martyalchin.com/2008/jan/10/simple-plugin-framework/
 
     it is under CC-BY-SA 3.0 US License
     (https://creativecommons.org/licenses/by-sa/3.0/us/)

--- a/basin3d/plugins/epa.py
+++ b/basin3d/plugins/epa.py
@@ -251,7 +251,7 @@ class EPAMonitoringFeatureAccess(DataSourcePluginAccess):
                     if mf_obj:
                         yield mf_obj
 
-        return StopIteration(synthesis_messages)
+        return StopIteration(synthesis_messages)  # type: ignore
 
     def get(self, query: QueryMonitoringFeature):
         """

--- a/basin3d/plugins/essdive.py
+++ b/basin3d/plugins/essdive.py
@@ -246,10 +246,9 @@ def _read_csv_to_pandas_df(filepath: pathlib.Path, columns_only: bool = False) -
 
         f.seek(0)
         header_ct = len(header_lines)
+        nrows: Optional[int] = None
         if columns_only:
             nrows = 2
-        else:
-            nrows = None
 
         pdf = pd.read_csv(f, header=header_ct, skipinitialspace=True, keep_default_na=False, on_bad_lines='warn', nrows=nrows)
 
@@ -821,6 +820,8 @@ def _build_locations_store(datasets: dict, mf_locations: list) -> Dict[Tuple, lo
                         continue
 
                     for col_name, col_info in header_store['variable_column_info'].items():
+                        lat: Optional[float] = None
+                        long: Optional[float] = None
                         try:
                             lat = float(col_info.get(HydroRFTerms.lat.value))
                             long = float(col_info.get(HydroRFTerms.long.value))

--- a/mypy.ini
+++ b/mypy.ini
@@ -8,4 +8,4 @@ warn_return_any = True
 warn_unused_configs = True
 ignore_missing_imports = True
 no_implicit_optional=False
-check_untyped_defs=(True|False)
+check_untyped_defs=False


### PR DESCRIPTION
What started as a single fix to updating a GH action turned into fixing a number of items in the GH actions workflow.

- Updates GitHub Workflow to Use `actions/upload-artifact@v3`.  Also bumps up all GH action versions that had warnings.
- Additionally fixes mypy typing errors due to the sensitivity of the latest version of mypy
- Fixes a broken link in the documentation by pointing to the wayback machine for a snapshot of the page representing the broken link


Closes #197

