### PR TITLE
bug(ci): fixes gh action artifact conflict error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,3 +57,8 @@ jobs:
       with:
         name: code-coverage-report
         path: ${{ github.workspace }}/artifacts
+        # If true, an artifact with a matching name will be deleted before a new one is uploaded.
+        # If false, the action will fail if an artifact for the given name already exists.
+        # Does not fail if the artifact does not exist.
+        # Optional. Default is 'false'
+        overwrite: true


### PR DESCRIPTION
Uses the github run_id for the artifact output directory

Closes #199
