### PR TITLE
Add Watershed Workflow geopandas view for monitoring features

### DIFF
--- a/basin3d/synthesis.py
+++ b/basin3d/synthesis.py
@@ -326,11 +326,11 @@ class DataSynthesizer:
             >>> from basin3d.plugins import usgs
             >>> from basin3d import synthesis
             >>> synthesizer = synthesis.register()
-            >>> timeseries = synthesizer.measurement_timeseries_tvp_observations(monitoring_feature=["USGS-09110990", (-106.7, 38.9, -106.5, 39.0)],observed_property=['RDC','WT'],start_date='2024-04-01',end_date='2024-04-30',aggregation_duration='NONE')
+            >>> timeseries = synthesizer.measurement_timeseries_tvp_observations(monitoring_feature=["USGS-09110990", (-106.7, 38.85, -106.5, 39.0)],observed_property=['RDC','WT'],start_date='2020-04-01',end_date='2020-04-05',aggregation_duration='NONE')
             >>> for timeseries in timeseries:
             ...    print(f"{timeseries.feature_of_interest.id} - {timeseries.observed_property.get_basin3d_vocab()}")
             USGS-09110990 - RDC
-            USGS-09106800 - RDC
+            USGS-09107000 - WT
 
         :param query: (optional) :class:`basin3d.core.schema.query.QueryMeasurementTimeseriesTVP` object
         :param kwargs: (required) Measurement Timeseries TVP Query parameters. See Query info below.

--- a/basin3d/views/watershed_workflow.py
+++ b/basin3d/views/watershed_workflow.py
@@ -1,0 +1,152 @@
+"""
+
+.. currentmodule:: basin3d.views.watershed_workflow
+
+:synopsis: output views for integration with Watershed Workflow
+:module author: Danielle Svehla Christianson <dschristianson@lbl.gov>
+
+Acknowledgements
+----------------
+The Watershed Workflow views are constructed in collaboration with Ethan Coon.
+
+"""
+
+import geopandas
+import shapely
+from typing import Optional
+
+from basin3d.core import monitor
+from basin3d.synthesis import DataSynthesizer
+
+logger = monitor.get_logger(__name__)
+
+
+def get_monitoring_features(synthesizer: DataSynthesizer, crs: str = 'EPSG:4326', **kwargs) -> geopandas.GeoDataFrame:
+    """
+    Acquire monitoring features that match the given query in a geopandas.GeoDataFrame output format.
+
+    :param synthesizer: DataSynthesizer configured with the desired data source plugins
+    :param crs: optional coordinate reference system, specific to the Watershed Workflow codebase. If provided, it will override the default EPSG:4326.
+    :param kwargs: arguments for the monitoring feature query that is passed to the :class:`~basin3d.synthesis.DataSynthesizer.monitoring_features` method.
+    :return: geopandas.GeoDataFrame with results of monitoring feature query.
+
+    Query arguments for the monitoring features include.
+      * feature_type: str (optional but recommended; and required by some data sources)
+      * datasource: list (optional but recommended)
+      * One of the following is required:
+        * monitoring_feature = list of one or more feature identifiers (str) and or bounding boxes (tuple)
+        * parent_feature = list of feature identifiers (str)
+
+    >>> from basin3d.plugins import usgs
+    >>> from basin3d import synthesis
+    >>> from basin3d.views import watershed_workflow as b3dww
+    >>> synthesizer = synthesis.register()
+    >>> monitoring_feature_geopandas = b3dww.get_monitoring_features(synthesizer, datasource=['USGS'], feature_type='point', monitoring_feature=[(-90.6, 34.4, -90.5, 34.6)])
+    >>> monitoring_feature_geopandas.shape
+    (2, 7)
+    >>> print(monitoring_feature_geopandas)
+                  id  ...                    geometry
+    0  USGS-07047970  ...    POINT (-90.58399 34.524)
+    1  USGS-07287700  ...  POINT (-90.53022 34.48425)
+    <BLANKLINE>
+    [2 rows x 7 columns]
+
+    """
+
+    class ColumnNames:
+        id = 'id'
+        name = 'name'
+        feature_type = 'feature_type'
+        description = 'description'
+        data_source = 'data_source'
+        elevation = 'elevation'
+
+    def extract_coordinates(mf) -> Optional[tuple]:
+        try:
+            if not mf.coordinates:
+                return None
+
+            abs_coord = mf.coordinates.absolute
+            if not abs_coord:
+                return None
+
+            # Extract horizontal position (longitude, latitude)
+            # ToDo: add check to compare datum to crs value
+            if abs_coord.horizontal_position:
+                # Get first position; note if the feature is not a point,
+                #    this could be a point location describing the feature
+                h_pos = abs_coord.horizontal_position[0]
+                longitude = h_pos.longitude
+                latitude = h_pos.latitude
+            else:
+                return None
+
+            # Extract elevation (optional)
+            elevation = None
+            if abs_coord.vertical_extent:
+                # Get first extent; note if the feature is not a point,
+                #    this could be a point location describing the feature
+                v_ext = abs_coord.vertical_extent[0]
+                elevation = getattr(v_ext, 'value', None)
+
+            return longitude, latitude, elevation
+
+        except Exception as e:
+            logger.warning(f"Failed to extract coordinates: {e}")
+            return None
+
+    empty_result_view = geopandas.GeoDataFrame(
+        columns=[ColumnNames.id, ColumnNames.name, ColumnNames.feature_type,
+                 ColumnNames.description, ColumnNames.data_source, ColumnNames.elevation],
+        geometry=[],
+        crs=crs)
+
+    monitoring_features: list = []
+
+    monitoring_features_generator = synthesizer.monitoring_features(**kwargs)
+
+    monitoring_features.extend(monitoring_features_generator)
+
+    # log any messages in executing the generator above
+    for msg in monitoring_features_generator.synthesis_response.messages:  # type: ignore
+        logger.info(msg)
+
+    if not monitoring_features:
+        logger.info('No monitoring features found for query parameters: {}'.format(kwargs))
+        return empty_result_view
+
+    results_geom = []
+    results_records = []
+
+    for monitoring_feature in monitoring_features:
+        mf_id = monitoring_feature.id
+
+        try:
+            loc_coords = extract_coordinates(monitoring_feature)
+            if not loc_coords:
+                logger.info(f'No coordinates available for {mf_id}')
+                continue
+            long, lat, elev = loc_coords
+            geom = shapely.geometry.Point(long, lat)
+
+            loc_record = {
+                ColumnNames.id: mf_id,
+                ColumnNames.name: getattr(monitoring_feature, 'name', ''),
+                ColumnNames.feature_type: getattr(monitoring_feature, 'feature_type', ''),
+                ColumnNames.description: getattr(monitoring_feature, 'description', ''),
+                ColumnNames.data_source: getattr(monitoring_feature, 'datasource', ''),
+                ColumnNames.elevation: elev
+            }
+
+            results_geom.append(geom)
+            results_records.append(loc_record)
+
+        except Exception as e:
+            logger.warning(f'Could not extract location info for {mf_id}: {e}')
+            continue
+
+    if all([results_geom, results_records, len(results_records) == len(results_geom)]):
+        return geopandas.GeoDataFrame(results_records, geometry=results_geom, crs=crs)
+
+    logger.warning('No parsable monitoring features were found.')
+    return empty_result_view

--- a/docs/_templates/indexcontent.html
+++ b/docs/_templates/indexcontent.html
@@ -12,16 +12,18 @@
                     <span class="linkdescr">Introduction to BASIN-3D</span></p>
                 <p class="biglink"><a class="biglink" href="{{ pathto("concepts") }}">Concepts in BASIN-3D</a><br/>
                     <span class="linkdescr">Short summary of the basic concepts</span></p>
-                <p class="biglink"><a class="biglink" href="{{ pathto("getting_started") }}#">Installation</a><br/>
-                    <span class="linkdescr">Instructions on installing BASIN-3D</span></p>
+                <p class="biglink"><a class="biglink" href="{{ pathto("plugins") }}">Data Source Plugins</a><br/>
+                    <span class="linkdescr">Data Sources supported by BASIN-3D</span></p>
             </td>
             <td width="70%">
+                <p class="biglink"><a class="biglink" href="{{ pathto("getting_started") }}#">Installation</a><br/>
+                    <span class="linkdescr">Instructions on installing BASIN-3D</span></p>
                 <p class="biglink"><a class="biglink" href="{{ pathto("quick_guide") }}">Quick Guide</a><br/>
                     <span class="linkdescr">Quick guide to basic functions</span></p>
                 <p class="biglink"><a class="biglink" href="{{ pathto("examples") }}">Examples</a><br/>
                     <span class="linkdescr">Examples for using BASIN-3D</span></p>
-                <p class="biglink"><a class="biglink" href="{{ pathto("plugins") }}">Data Source Plugins</a><br/>
-                    <span class="linkdescr">Data Sources supported by BASIN-3D</span></p>
+                <p class="biglink"><a class="biglink" href="{{ pathto("views") }}">Views</a><br/>
+                    <span class="linkdescr">Query Result Formats</span></p>
             </td>
         </tr>
     </table>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -256,7 +256,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (master_doc, 'basin3d-{}.tex'.format(version), 'basin3d Documentation',
-     'Charuleka Varadharajan, Valerie Hendrix', 'manual'),
+     'Charuleka Varadharajan, Valerie Hendrix, Danielle S. Christianson', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,10 +5,11 @@ Welcome to basin3d-core |release| documentation!
 
    intro
    concepts
-   getting_started
    plugins
+   getting_started
    quick_guide
    examples
+   views
    key_functions
    api_reference
    changelog

--- a/docs/views.rst
+++ b/docs/views.rst
@@ -1,0 +1,48 @@
+.. _basin3dviews:
+
+Views
+*****
+
+BASIN-3D Views is a collection of BASIN-3D results (e.g., Monitoring Features, Measurement Timeseries TVP Observations)
+formatted in common data structures, like GeoPandas Geo Data Frames.
+
+.. _watershed_workflows_monitoring_features_geopandas:
+
+Watershed Workflows - Monitoring Features GeoPandas View
+--------------------------------------------------------
+
+Watershed Workflows is a python-based, open source chain of tools for generating meshes and other data inputs
+for hyper-resolution hydrology.
+See https://environmental-modeling-workflows.github.io/watershed-workflow/stable/index.html
+
+The BASIN-3D Monitoring Feature GeoPandas View was developed in coordination with Ethan Coon to support
+acquisition of USGS water monitoring location information using BASIN-3D tools.
+
+
+Usage
+^^^^^
+.. code-block::
+
+    >>> from basin3d.plugins import usgs
+    >>> from basin3d import synthesis
+    >>> from basin3d.views import watershed_workflow as b3dww
+    >>> synthesizer = synthesis.register()
+    >>> monitoring_feature_geopandas = b3dww.get_monitoring_features(synthesizer, datasource=['USGS'], feature_type='point', monitoring_feature=[(-90.6, 34.4, -90.5, 34.6)])
+    >>> monitoring_feature_geopandas.shape
+    (2, 7)
+    >>> print(monitoring_feature_geopandas)
+                  id                             name feature_type description data_source  elevation                    geometry
+    0  USGS-07047970  MISSISSIPPI RIVER AT HELENA, AR        POINT        None        USGS      141.7    POINT (-90.58399 34.524)
+    1  USGS-07287700     PHILLIPS BAYOU AT POWELL, MS        POINT        None        USGS        NaN  POINT (-90.53022 34.48425)
+
+    [2 rows x 7 columns]
+
+
+Note: The coordinate reference system (CRS) is by default ESPG:4326 (WGS84). An alternative CRS may be provided by including the parameter crs in the get_monitoring_features call.
+
+
+Technical details
+^^^^^^^^^^^^^^^^^
+
+.. autofunction:: basin3d.views.watershed_workflow.get_monitoring_features
+    :noindex:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,11 +36,13 @@ license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = '>=3.10,<3.13'
 dependencies = [
+    "geopandas",
     "pandas",
     "pydantic<2",
     "pyyaml>=6.0",
     "requests",
-    'SQLAlchemy>=1.4',
+    "shapely",
+    "SQLAlchemy>=1.4",
 ]
 
 

--- a/tests/test_views_watershed_workflow.py
+++ b/tests/test_views_watershed_workflow.py
@@ -1,0 +1,166 @@
+import datetime as dt
+import json
+import logging
+import pytest
+
+from geopandas import GeoDataFrame
+from os.path import dirname
+from unittest.mock import MagicMock
+
+from basin3d.synthesis import register
+from basin3d.views import watershed_workflow as b3dww
+from tests.utilities import get_text, get_json
+
+
+def get_url_json(data, status=200):
+    """
+    Creates a get_url call for mocking with the specified return data
+    :param data:
+    :param status:
+    :return:
+    """
+    return type('Dummy', (object,), {
+        "content": data,
+        "status_code": status,
+        "url": "/testurl"})
+
+
+def get_url(data, status=200):
+    """
+    Creates a get_url call for mocking with the specified return data
+    :param data:
+    :return:
+    """
+    return type('Dummy', (object,), {
+        "json": lambda: data,
+        "status_code": status,
+        "url": "/testurl"})
+
+
+def get_url_text(text, status=200):
+    """
+    Creates a get_url_text call for mocking with the specified return data
+    :param text:
+    :return:
+    """
+
+    return type('Dummy', (object,), {
+        "text": text,
+        "status_code": status,
+        "url": "/testurl"})
+
+# test USGS
+def test_get_monitoring_features(monkeypatch):
+    mock_get_url = MagicMock(side_effect=list(
+        [get_url_text(get_text("usgs_mf_query_point_single_bbox.rdb"))]))
+
+    from basin3d.plugins import usgs
+    monkeypatch.setattr(usgs, 'get_url', mock_get_url)
+
+    synthesizer = register(['basin3d.plugins.usgs.USGSDataSourcePlugin'])
+
+    monitoring_feature_geopandas = b3dww.get_monitoring_features(
+        synthesizer, datasource=['USGS'], feature_type='point',
+        monitoring_feature=[(-106.7, 38.9, -106.5, 39.0)])
+
+    assert isinstance(monitoring_feature_geopandas, GeoDataFrame)
+    assert list(monitoring_feature_geopandas.columns) == [
+        'id', 'name', 'feature_type', 'description', 'data_source', 'elevation', 'geometry']
+    assert monitoring_feature_geopandas.shape == (1,7)
+    geometry = monitoring_feature_geopandas.get_geometry(0)
+    assert float(geometry.x[0]) == -106.6009444
+    assert float(geometry.y[0]) == 38.92469444
+    assert monitoring_feature_geopandas.get('id')[0] == 'USGS-09106800'
+    assert monitoring_feature_geopandas.get('feature_type')[0] == 'POINT'
+    assert monitoring_feature_geopandas.get('name')[0] == 'TAYLOR RIVER ABOVE TRAIL CREEK NR TAYLOR PARK, CO'
+    assert monitoring_feature_geopandas.get('data_source')[0].id == 'USGS'
+    assert monitoring_feature_geopandas.get('elevation')[0] == 9681.31
+
+
+# test empty result with message
+def test_get_monitoring_features_msg(caplog, monkeypatch):
+    caplog.set_level(logging.INFO)
+    caplog.clear()
+
+    mock_get_url = MagicMock(side_effect=list(
+        [get_url_text(get_text("usgs_mf_query_bbox_empty.rdb"))]))
+
+    from basin3d.plugins import usgs
+    monkeypatch.setattr(usgs, 'get_url', mock_get_url)
+
+    synthesizer = register(['basin3d.plugins.usgs.USGSDataSourcePlugin'])
+
+    monitoring_feature_geopandas = b3dww.get_monitoring_features(
+        synthesizer, datasource=['USGS'], feature_type='point',
+        monitoring_feature=[(-90.6, 34.4, -90.5, 34.43)])
+
+    log_msg = caplog.records[-1]
+    assert log_msg.msg == "No monitoring features found for query parameters: {'datasource': ['USGS'], 'feature_type': 'point', 'monitoring_feature': [(-90.6, 34.4, -90.5, 34.43)]}"
+    assert monitoring_feature_geopandas.size == 0
+    assert list(monitoring_feature_geopandas.columns) == [
+        'id', 'name', 'feature_type', 'description', 'data_source', 'elevation', 'geometry']
+
+
+# test EPA -- only names supported
+def test_get_monitoring_features_epa(caplog, monkeypatch):
+    caplog.set_level(logging.INFO)
+    caplog.clear()
+
+    mock_get_url = MagicMock(side_effect=list([get_url_json(get_text('epa_loc_single.json')), get_url_json(get_text('epa_mock.json'))]))
+
+    from basin3d.plugins import epa
+    monkeypatch.setattr(epa, 'get_url', mock_get_url)
+
+    synthesizer = register(['basin3d.plugins.epa.EPADataSourcePlugin'])
+
+    monitoring_feature_geopandas = b3dww.get_monitoring_features(
+        synthesizer, datasource=['EPA'], feature_type='point',
+        monitoring_feature=['EPA-0801417-CB-AS-1'])
+
+    assert isinstance(monitoring_feature_geopandas, GeoDataFrame)
+    assert list(monitoring_feature_geopandas.columns) == [
+        'id', 'name', 'feature_type', 'description', 'data_source', 'elevation', 'geometry']
+    assert monitoring_feature_geopandas.shape == (1, 7)
+    geometry = monitoring_feature_geopandas.get_geometry(0)
+    assert float(geometry.x[0]) == -107.25
+    assert float(geometry.y[0]) == 37.95
+    assert monitoring_feature_geopandas.get('id')[0] == 'EPA-0801417-CB-AS-1'
+    assert monitoring_feature_geopandas.get('feature_type')[0] == 'POINT'
+    assert monitoring_feature_geopandas.get('description')[0] == 'Location is part of USGS huc 14020002; organization Red Mountain Pass Zinc (US EPA Region 8); provider EPA STORET'
+    assert monitoring_feature_geopandas.get('data_source')[0].id == 'EPA'
+    assert monitoring_feature_geopandas.get('elevation')[0] is None
+
+    monitoring_feature_geopandas = b3dww.get_monitoring_features(
+        synthesizer, datasource=['EPA'], feature_type='point',
+        monitoring_feature=[(-90.6, 34.4, -90.5, 34.43)])
+
+    log_msg = caplog.records[-1]
+    assert log_msg.msg == "No monitoring features found for query parameters: {'datasource': ['EPA'], 'feature_type': 'point', 'monitoring_feature': [(-90.6, 34.4, -90.5, 34.43)]}"
+    assert monitoring_feature_geopandas.size == 0
+    assert list(monitoring_feature_geopandas.columns) == [
+        'id', 'name', 'feature_type', 'description', 'data_source', 'elevation', 'geometry']
+
+
+# test malformed monitoring feature request
+def test_malformed_monitoring_feature(caplog, monkeypatch):
+    caplog.set_level(logging.INFO)
+    caplog.clear()
+
+    mock_get_url = MagicMock(side_effect=list(
+        [get_url_text(get_text("usgs_mf_query_bbox_empty.rdb"))]))
+
+    from basin3d.plugins import usgs
+    monkeypatch.setattr(usgs, 'get_url', mock_get_url)
+
+    synthesizer = register(['basin3d.plugins.usgs.USGSDataSourcePlugin'])
+
+    monitoring_feature_geopandas = b3dww.get_monitoring_features(
+        synthesizer, datasource=['USGS'], feature_type='point')
+
+    assert isinstance(monitoring_feature_geopandas, GeoDataFrame)
+
+    log_msg = caplog.records[-1]
+    assert log_msg.msg == "No monitoring features found for query parameters: {'datasource': ['USGS'], 'feature_type': 'point'}"
+    assert monitoring_feature_geopandas.size == 0
+    assert list(monitoring_feature_geopandas.columns) == [
+        'id', 'name', 'feature_type', 'description', 'data_source', 'elevation', 'geometry']


### PR DESCRIPTION
Adds functionality to represent Monitoring Feature results as Geopandas GeoDataFrame for Watershed Workflows.

Adds documentation for Views in the Documentation.

Note: Integration tests will be added in issue #228. 

Closes #224

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests 
- [x] Test coverage >= 90%
- [x] Flake8 Tests 
- [x] Mypy Tests 

### Test Configuration
* Python Version: 3.10, 3.11, 3.12

## PR Self Evaluation
strikethrough things that don’t make sense for your PR

- [x] My code follows the agreed upon best practices
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests or modified existing tests that prove my fix is effective or that my feature works
- [x] Existing unit tests pass locally with my changes
~- [ ] Any dependent changes have been merged and published in the appropriate modules~
- [x] I have performed a self-review of my own code

